### PR TITLE
feat: support async callbacks in setRules

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -259,7 +259,7 @@ export class Guantr<
     }
 
     const rules: GuantrAnyRule[] = [];
-    callbackOrRules(
+    const result = callbackOrRules(
       (action, resource) =>
         rules.push({
           action,
@@ -277,6 +277,10 @@ export class Guantr<
           effect: 'deny',
         }),
     );
+
+    if (result && typeof result.then === 'function') {
+      await result;
+    }
 
     if (this._strict) {
       for (const rule of rules) {
@@ -567,7 +571,7 @@ type SetRulesCallback<
           GuantrRule<Meta, Context, ResourceKey>['condition'],
         ],
   ) => void,
-) => void;
+) => void | Promise<void>;
 
 export async function createGuantr<
   Meta extends GuantrMeta<GuantrResourceMap> | undefined = undefined,

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -817,3 +817,173 @@ describe('Guantr.can.abstract / cannot.abstract', () => {
     expect(abstract).toBe(!abstractNot);
   });
 });
+
+describe('Guantr.setRules with async callback', () => {
+  test('should capture rules defined before await', async () => {
+    const guantr = await createGuantr<MockMeta>();
+    await guantr.setRules(async (can) => {
+      can('read', 'post');
+      await Promise.resolve();
+    });
+
+    const rules = await guantr.getRules();
+    expect(rules).toContainEqual({
+      action: 'read',
+      resource: 'post',
+      condition: null,
+      effect: 'allow',
+    });
+  });
+
+  test('should capture rules defined after await', async () => {
+    const guantr = await createGuantr<MockMeta>();
+    await guantr.setRules(async (can, cannot) => {
+      can('read', 'post');
+      await Promise.resolve();
+      cannot('delete', 'post');
+    });
+
+    const rules = await guantr.getRules();
+    expect(rules).toContainEqual({
+      action: 'read',
+      resource: 'post',
+      condition: null,
+      effect: 'allow',
+    });
+    expect(rules).toContainEqual({
+      action: 'delete',
+      resource: 'post',
+      condition: null,
+      effect: 'deny',
+    });
+  });
+
+  test('should capture rules with conditions defined after await', async () => {
+    const guantr = await createGuantr<MockMeta>();
+    await guantr.setRules(async (can) => {
+      can('read', 'post');
+      await Promise.resolve();
+      can('read', ['post', { published: ['eq', true] }]);
+    });
+
+    const rules = await guantr.getRules();
+    expect(rules).toHaveLength(2);
+    expect(rules).toContainEqual({
+      action: 'read',
+      resource: 'post',
+      condition: null,
+      effect: 'allow',
+    });
+    expect(rules).toContainEqual({
+      action: 'read',
+      resource: 'post',
+      condition: { published: ['eq', true] },
+      effect: 'allow',
+    });
+  });
+
+  test('should work with real async operations like fetch-like delays', async () => {
+    const guantr = await createGuantr<MockMeta>();
+
+    // Simulate fetching rules from an external source
+    const fetchUserPermissions = async () => {
+      // Simulate network delay
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      return { canCreate: true, canDelete: false } as const;
+    };
+
+    await guantr.setRules(async (can, cannot) => {
+      can('read', 'post');
+      const permissions = await fetchUserPermissions();
+      if (permissions.canCreate) {
+        can('create', 'post');
+      }
+      if (!permissions.canDelete) {
+        cannot('delete', 'post');
+      }
+    });
+
+    const rules = await guantr.getRules();
+    expect(rules).toContainEqual({
+      action: 'read',
+      resource: 'post',
+      condition: null,
+      effect: 'allow',
+    });
+    expect(rules).toContainEqual({
+      action: 'create',
+      resource: 'post',
+      condition: null,
+      effect: 'allow',
+    });
+    expect(rules).toContainEqual({
+      action: 'delete',
+      resource: 'post',
+      condition: null,
+      effect: 'deny',
+    });
+  });
+
+  test('should work with sync callbacks unchanged', async () => {
+    const guantr = await createGuantr<MockMeta>();
+    await guantr.setRules((can, cannot) => {
+      can('read', 'post');
+      cannot('delete', 'post');
+    });
+
+    const rules = await guantr.getRules();
+    expect(rules).toHaveLength(2);
+    expect(rules).toContainEqual({
+      action: 'read',
+      resource: 'post',
+      condition: null,
+      effect: 'allow',
+    });
+    expect(rules).toContainEqual({
+      action: 'delete',
+      resource: 'post',
+      condition: null,
+      effect: 'deny',
+    });
+  });
+
+  test('should handle async callback that returns nothing (only await)', async () => {
+    const guantr = await createGuantr<MockMeta>();
+    await guantr.setRules(async (can) => {
+      can('read', 'post');
+      // Just awaiting something without defining more rules
+      await Promise.resolve();
+    });
+
+    const rules = await guantr.getRules();
+    expect(rules).toHaveLength(1);
+    expect(rules[0]).toMatchObject({
+      action: 'read',
+      resource: 'post',
+      effect: 'allow',
+    });
+  });
+
+  test('should clear rules and set new ones with async callback', async () => {
+    const guantr = await createGuantr<MockMeta>();
+
+    // Set initial rules
+    await guantr.setRules((can) => {
+      can('read', 'user');
+    });
+
+    // Replace with async callback
+    await guantr.setRules(async (can) => {
+      await Promise.resolve();
+      can('read', 'post');
+    });
+
+    const rules = await guantr.getRules();
+    expect(rules).toHaveLength(1);
+    expect(rules[0]).toMatchObject({
+      action: 'read',
+      resource: 'post',
+      effect: 'allow',
+    });
+  });
+});


### PR DESCRIPTION
Callback type changed to return void | Promise<void>. setRules now awaits the callback if it returns a promise.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

Closes #77

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
