### PR TITLE
feat!: remove string-mode from can and cannot

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,10 @@ const guantr = await createGuantr<Meta>([
 Authorize:
 
 ```js
-await guantr.can('read', 'post'); // true
+// Abstract check — verify any allow rule exists (for UI hints)
+await guantr.can.abstract('read', 'post'); // true
 
+// Resource-aware check — full evaluation against a specific instance
 const post = {
   id: 1,
   title: 'Hello World',

--- a/docs/api/Guantr/can.abstract.md
+++ b/docs/api/Guantr/can.abstract.md
@@ -48,21 +48,26 @@ const canRead = await guantr.can('read', ['post', unpublishedPost]);
 
 ## Contrast with `can()`
 
-| Behaviour            | `can(action, 'resource')` _(deprecated)_ | `can.abstract(action, 'resource')` | `can(action, ['resource', instance])` |
-| -------------------- | ---------------------------------------- | ---------------------------------- | ------------------------------------- |
-| Checks allow rules   | ✅                                       | ✅                                 | ✅                                    |
-| Evaluates conditions | ❌                                       | ❌                                 | ✅                                    |
-| Evaluates deny rules | ❌                                       | ❌                                 | ✅                                    |
-| Recommended for      | — _(use can.abstract)_                   | UI hints                           | Access control                        |
+| Behaviour            | `can.abstract(action, 'resource')` | `can(action, ['resource', instance])` |
+| -------------------- | ---------------------------------- | ------------------------------------- |
+| Checks allow rules   | ✅                                 | ✅                                    |
+| Evaluates conditions | ❌                                 | ✅                                    |
+| Evaluates deny rules | ❌                                 | ✅                                    |
+| Recommended for      | UI hints                           | Access control                        |
 
-## Migration from `can()` string-mode
+## Migration from v1.x
+
+The string overload `can(action, 'resourceKey')` was deprecated in v1.1.0 and **removed in v2.0.0**. Replace all such calls with `can.abstract`:
 
 ```ts
-// Before (v1.0.x) — implicit, easy to misuse
+// v1.x — removed in v2.0.0
 await guantr.can('read', 'post');
 
-// After (v1.1.0) — explicit intent
+// v2.0.0 — use can.abstract for abstract checks
 await guantr.can.abstract('read', 'post');
+
+// v2.0.0 — use the tuple form for full evaluation
+await guantr.can('read', ['post', postInstance]);
 ```
 
 See also: [`cannot.abstract`](./cannot.abstract), [`can`](./can), [Concepts: Abstract vs Resource-Aware Checks](../../guides/abstract-vs-resource-aware).

--- a/docs/api/Guantr/can.md
+++ b/docs/api/Guantr/can.md
@@ -1,6 +1,6 @@
 # API: `Guantr.prototype.can`
 
-The `can` method checks if a specific action is permitted on a given resource, according to the rules defined in the Guantr instance. It considers both `allow` and `deny` rules, including any applicable conditions based on the resource instance and context.
+The `can` method checks if a specific action is permitted on a given resource instance, according to the rules defined in the Guantr instance. It evaluates both `allow` and `deny` rules, including any applicable conditions based on the resource instance and context.
 
 > For an abstract check that only tests whether any allow rule exists (without evaluating conditions or deny rules), see [`can.abstract`](./can.abstract).
 
@@ -10,7 +10,7 @@ The `can` method checks if a specific action is permitted on a given resource, a
 interface Guantr<Meta, Context> {
   can(
     action: string, // Or specific action type from Meta
-    resource: string | [resourceKey: string, resourceInstance: object], // Or typed resource key/instance from Meta
+    resource: [resourceKey: string, resourceInstance: object], // Or typed resource key/instance from Meta
   ): Promise<boolean>;
 }
 ```
@@ -18,9 +18,7 @@ interface Guantr<Meta, Context> {
 ## Parameters
 
 - `action`: (`string`) The action being attempted (e.g., `'read'`, `'update'`).
-- `resource`: (`string` | `[string, object]`) The resource being acted upon.
-  - If a `string` (e.g., `'post'`) is provided, it checks rules defined for the general resource type _without_ evaluating instance-specific conditions. **Deprecated** — use [`can.abstract`](./can.abstract) instead for this behaviour.
-  - If a tuple `[resourceKey: string, resourceInstance: object]` (e.g., `['post', { id: 1, status: 'draft' }]`) is provided, it checks rules for the `resourceKey` and evaluates any conditions against the properties of the `resourceInstance` and the current context.
+- `resource`: (`[string, object]`) A tuple of `[resourceKey, resourceInstance]` (e.g., `['post', { id: 1, status: 'draft' }]`). Rules for the `resourceKey` are retrieved and any conditions are evaluated against the `resourceInstance` and the current context.
 
 ## Returns
 
@@ -30,8 +28,8 @@ interface Guantr<Meta, Context> {
 
 ## How it Works
 
-1.  Retrieves all rules relevant to the given `action` and `resource` key using `queryRules` from the storage adapter.
-2.  If a `resourceInstance` is provided, it evaluates the `condition` of each relevant rule against the instance's properties and the current context (obtained via `getContext`).
+1.  Retrieves all rules relevant to the given `action` and resource key using `queryRules` from the storage adapter.
+2.  Evaluates the `condition` of each rule against the `resourceInstance`'s properties and the current context (obtained via `getContext`).
 3.  Determines the outcome: Permission is granted (`true`) if there's at least one applicable `allow` rule and no applicable `deny` rules. Otherwise, permission is denied (`false`).
 
 ## Examples
@@ -48,10 +46,6 @@ const someoneElsesArticle = { id: 3, status: 'published', ownerId: 'user-456' };
 
 // Assume current context userId is 'user-123'
 
-// Check general read permission (doesn't evaluate conditions)
-const canReadType = await guantr.can('read', 'article');
-// -> true (because the general 'allow read article' rule exists)
-
 // Check read permission on specific instances
 const canReadActive = await guantr.can('read', ['article', activeArticle]);
 // -> true (general 'allow' applies, 'deny' condition doesn't match)
@@ -66,3 +60,5 @@ const canEditOwn = await guantr.can('edit', ['article', activeArticle]);
 const canEditElse = await guantr.can('edit', ['article', someoneElsesArticle]);
 // -> false (condition ownerId === $ctx.userId does not match)
 ```
+
+> To check whether any permission exists for a resource type without a specific instance (e.g., for showing/hiding a UI button), use [`can.abstract`](./can.abstract).

--- a/docs/api/Guantr/cannot.abstract.md
+++ b/docs/api/Guantr/cannot.abstract.md
@@ -36,4 +36,19 @@ const showEditButton = !(await guantr.cannot.abstract('update', 'post'));
 // -> true (allow rule exists — show the button)
 ```
 
+## Migration from v1.x
+
+The string overload `cannot(action, 'resourceKey')` was deprecated in v1.1.0 and **removed in v2.0.0**. Replace all such calls with `cannot.abstract`:
+
+```ts
+// v1.x — removed in v2.0.0
+await guantr.cannot('read', 'post');
+
+// v2.0.0 — use cannot.abstract for abstract checks
+await guantr.cannot.abstract('read', 'post');
+
+// v2.0.0 — use the tuple form for full evaluation
+await guantr.cannot('read', ['post', postInstance]);
+```
+
 See also: [`can.abstract`](./can.abstract), [`cannot`](./cannot), [Concepts: Abstract vs Resource-Aware Checks](../../guides/abstract-vs-resource-aware).

--- a/docs/api/Guantr/cannot.md
+++ b/docs/api/Guantr/cannot.md
@@ -1,6 +1,8 @@
 # API: `Guantr.prototype.cannot`
 
-The `cannot` method checks if a specific action is explicitly or implicitly denied on a given resource. It is the logical negation of the `can` method.
+The `cannot` method checks if a specific action is explicitly or implicitly denied on a given resource instance. It is the logical negation of the `can` method.
+
+> For an abstract check that only tests whether any allow rule is absent (without evaluating conditions or deny rules), see [`cannot.abstract`](./cannot.abstract).
 
 ## Signature
 
@@ -8,7 +10,7 @@ The `cannot` method checks if a specific action is explicitly or implicitly deni
 interface Guantr<Meta, Context> {
   cannot(
     action: string, // Or specific action type from Meta
-    resource: string | [resourceKey: string, resourceInstance: object], // Or typed resource key/instance from Meta
+    resource: [resourceKey: string, resourceInstance: object], // Or typed resource key/instance from Meta
   ): Promise<boolean>;
 }
 ```
@@ -16,9 +18,7 @@ interface Guantr<Meta, Context> {
 ## Parameters
 
 - `action`: (`string`) The action being attempted (e.g., `'read'`, `'update'`).
-- `resource`: (`string` | `[string, object]`) The resource being acted upon.
-  - If a `string` (e.g., `'post'`) is provided, it checks rules defined for the general resource type _without_ evaluating instance-specific conditions.
-  - If a tuple `[resourceKey: string, resourceInstance: object]` (e.g., `['post', { id: 1, status: 'draft' }]`) is provided, it checks rules for the `resourceKey` and evaluates any conditions against the properties of the `resourceInstance` and the current context.
+- `resource`: (`[string, object]`) A tuple of `[resourceKey, resourceInstance]` (e.g., `['post', { id: 1, status: 'draft' }]`). Rules for the `resourceKey` are retrieved and any conditions are evaluated against the `resourceInstance` and the current context.
 
 ## Returns
 
@@ -33,7 +33,7 @@ Essentially, `guantr.cannot(...)` is equivalent to `!await guantr.can(...)`.
 It follows the same internal logic as the `can` method but returns the opposite boolean result.
 
 1.  Retrieves relevant rules.
-2.  Evaluates conditions if a `resourceInstance` is provided.
+2.  Evaluates conditions against the `resourceInstance` and the current context.
 3.  Determines the outcome based on matching `allow` and `deny` rules.
 4.  Returns `true` if the effective permission is "deny", `false` otherwise.
 
@@ -64,8 +64,6 @@ const cannotEditOwn = await guantr.cannot('edit', ['article', activeArticle]);
 
 const cannotEditElse = await guantr.cannot('edit', ['article', someoneElsesArticle]);
 // -> true (editing someone else's article is implicitly denied as no rule allows it)
-
-// Check action not defined in rules
-const cannotPublish = await guantr.cannot('publish', 'article');
-// -> true (implicitly denied as no 'allow publish article' rule exists)
 ```
+
+> To check whether no permission exists for a resource type without a specific instance (e.g., for hiding a UI button), use [`cannot.abstract`](./cannot.abstract).

--- a/docs/guides/abstract-vs-resource-aware.md
+++ b/docs/guides/abstract-vs-resource-aware.md
@@ -65,32 +65,18 @@ await guantr.can('update', ['post', publishedPost]);
 // -> false (allow matches, but deny also matches — deny wins)
 ```
 
-## Why the String Overload of `can()` is Deprecated
+## Migration from v1.x
 
-Prior to v1.1.0, calling `can('update', 'post')` (string-mode) silently performed an abstract check. This was easy to misuse — developers could accidentally rely on it for access control decisions while it was actually just checking for rule existence.
-
-In v1.1.0:
-
-- `can(action, 'resourceKey')` is **deprecated** and emits a `console.warn` in non-production environments.
-- Use `can.abstract(action, 'resourceKey')` for the same behaviour with explicit intent.
-- Use `can(action, ['resourceKey', instance])` for full evaluation.
+Prior to v2.0.0, calling `can('update', 'post')` with a plain string silently performed an abstract check. This was deprecated in v1.1.0 and **removed in v2.0.0** because it was easy to misuse — developers could accidentally rely on it for access control decisions while it was only checking for rule existence.
 
 ```ts
-// v1.0.x — ambiguous
-await guantr.can('update', 'post'); // ❌ deprecated
+// v1.x — no longer compiles in v2.0.0
+await guantr.can('update', 'post');
+await guantr.cannot('update', 'post');
 
-// v1.1.0 — explicit intent
+// v2.0.0 — use dedicated methods with explicit intent
 await guantr.can.abstract('update', 'post'); // ✅ UI hints
+await guantr.cannot.abstract('update', 'post'); // ✅ UI hints (negated)
 await guantr.can('update', ['post', post]); // ✅ access control
-```
-
-## Dev-Mode Warnings
-
-The deprecation warning is emitted once per unique `action + resource` pair and is suppressed in production environments (`process.env.NODE_ENV === 'production'`).
-
-You can also disable it manually:
-
-```ts
-import { Guantr } from 'guantr';
-Guantr.devWarnings = false;
+await guantr.cannot('update', ['post', post]); // ✅ access control (negated)
 ```

--- a/docs/guides/example-basic-rbac.md
+++ b/docs/guides/example-basic-rbac.md
@@ -83,11 +83,11 @@ app.delete('/api/articles/:id', async (req, res) => {
   // Get Guantr instance for this request/user
   const guantr = await getGuantrForRequest(req); // Or setupGuantrForRole(userRole)
 
-  // Check if the user's role allows deleting 'article'
-  // This checks the general action type based on the loaded rules.
-  const canDelete = await guantr.can('delete', 'article');
+  // Abstract check — verify any allow rule exists for 'delete' on 'article'.
+  // Use this for early UI-layer guards. For actual enforcement, always check against a specific instance.
+  const canDelete = await guantr.can.abstract('delete', 'article');
 
-  // If the rules involved conditions, you would check against the specific instance:
+  // For full evaluation against a specific resource instance:
   // const canDeleteSpecific = await guantr.can('delete', ['article', article]);
 
   if (!canDelete) {

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -35,7 +35,7 @@ await guantr.setRules((can, cannot) => {
 Verify permissions easily using the `can` or `cannot` methods.
 
 ```ts
-await guantr.can('read', 'post'); // Check if reading posts is generally allowed
+await guantr.can.abstract('read', 'post'); // Check if reading posts is generally allowed (abstract, for UI hints)
 const post = { id: 1, title: 'Hello, World!', archived: true };
 await guantr.cannot('read', ['post', post]); // Check if reading *this specific* archived post is denied
 ```

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -165,8 +165,8 @@ await guantr.setRules(rules);
 Use the `can` (or `cannot`) method to check if an action is permitted. Pass the specific resource object when checking rules that involve conditions.
 
 ```ts
-// Check general permission to read posts
-const canReadAnyPost = await guantr.can('read', 'post');
+// Abstract check — verify any allow rule exists for this resource type (for UI hints)
+const canReadAnyPost = await guantr.can.abstract('read', 'post');
 console.log('Can read any post?', canReadAnyPost); // Likely true based on rules above
 
 // Check permission to read a specific archived post

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,23 +50,8 @@ type ExtractResourceModel<Meta, K> =
  */
 type CanMethod<Meta extends GuantrMeta<GuantrResourceMap> | undefined> = {
   /**
-   * @deprecated String-mode does NOT evaluate conditions or deny rules — only checks if any allow rule exists.
-   * Use `can.abstract()` for this behavior, or `can(action, [resourceKey, instance])` for full evaluation.
-   */
-  <ResourceKey extends ExtractResourceKeys<Meta>>(
-    action: ExtractResourceAction<Meta, ResourceKey>,
-    resource: ResourceKey,
-  ): Promise<boolean>;
-
-  /**
    * Checks if the user has permission to perform the specified action on the given resource instance.
    * Evaluates all matching conditions and deny rules.
-   *
-   * @template ResourceKey - The type of the resource key.
-   * @template Resource - The type of the resource model.
-   * @param action - The action to check.
-   * @param resource - A tuple of `[resourceKey, resourceInstance]`.
-   * @returns `true` if at least one allow rule matches and no deny rule matches.
    */
   <
     ResourceKey extends ExtractResourceKeys<Meta>,
@@ -83,9 +68,6 @@ type CanMethod<Meta extends GuantrMeta<GuantrResourceMap> | undefined> = {
    * Abstract permission check.
    * Returns `true` if ANY allow rule exists for the given action + resource pair.
    * Does NOT evaluate conditions or deny rules.
-   *
-   * Use for UI hints (e.g. "should I show the Edit button?"), NOT for access control decisions.
-   * For full evaluation against a resource instance, use `can(action, [resourceKey, instance])`.
    */
   abstract<ResourceKey extends ExtractResourceKeys<Meta>>(
     action: ExtractResourceAction<Meta, ResourceKey>,
@@ -98,23 +80,8 @@ type CanMethod<Meta extends GuantrMeta<GuantrResourceMap> | undefined> = {
  */
 type CannotMethod<Meta extends GuantrMeta<GuantrResourceMap> | undefined> = {
   /**
-   * @deprecated String-mode does NOT evaluate conditions or deny rules — only checks if any allow rule exists.
-   * Use `cannot.abstract()` for this behavior, or `cannot(action, [resourceKey, instance])` for full evaluation.
-   */
-  <ResourceKey extends ExtractResourceKeys<Meta>>(
-    action: ExtractResourceAction<Meta, ResourceKey>,
-    resource: ResourceKey,
-  ): Promise<boolean>;
-
-  /**
    * Checks if the user does NOT have permission to perform the specified action on the given resource instance.
    * Evaluates all matching conditions and deny rules.
-   *
-   * @template ResourceKey - The type of the resource key.
-   * @template Resource - The type of the resource model.
-   * @param action - The action to check.
-   * @param resource - A tuple of `[resourceKey, resourceInstance]`.
-   * @returns `true` if no allow rule matches, or a deny rule matches.
    */
   <
     ResourceKey extends ExtractResourceKeys<Meta>,
@@ -131,8 +98,6 @@ type CannotMethod<Meta extends GuantrMeta<GuantrResourceMap> | undefined> = {
    * Abstract permission check (negated).
    * Returns `true` if NO allow rule exists for the given action + resource pair.
    * Does NOT evaluate conditions or deny rules.
-   *
-   * Use for UI hints (e.g. "should I hide the Delete button?"), NOT for access control decisions.
    */
   abstract<ResourceKey extends ExtractResourceKeys<Meta>>(
     action: ExtractResourceAction<Meta, ResourceKey>,
@@ -150,30 +115,18 @@ export class Guantr<
   private readonly _strict: boolean;
 
   /**
-   * Controls whether deprecation warnings are emitted for string-mode `can()` usage.
-   * Automatically enabled in non-production environments. Can be disabled via `Guantr.devWarnings = false`.
-   */
-  static devWarnings: boolean =
-    (globalThis as { process?: { env?: { NODE_ENV?: string } } }).process?.env?.NODE_ENV !==
-    'production';
-
-  private static readonly _stringModeWarnedKeys = new Set<string>();
-
-  /**
    * Check whether an action is permitted on a resource.
    *
-   * - `can(action, resourceKey)` — *(deprecated)* abstract check; ignores conditions and deny rules.
    * - `can(action, [resourceKey, instance])` — full evaluation against the resource instance.
-   * - `can.abstract(action, resourceKey)` — explicit abstract check for UI hints.
+   * - `can.abstract(action, resourceKey)` — abstract check for UI hints; ignores conditions and deny rules.
    */
   readonly can!: CanMethod<Meta>;
 
   /**
    * Check whether an action is denied on a resource. Logical negation of `can`.
    *
-   * - `cannot(action, resourceKey)` — *(deprecated)* abstract check; ignores conditions and deny rules.
    * - `cannot(action, [resourceKey, instance])` — full evaluation against the resource instance.
-   * - `cannot.abstract(action, resourceKey)` — explicit abstract check for UI hints.
+   * - `cannot.abstract(action, resourceKey)` — abstract check for UI hints; ignores conditions and deny rules.
    */
   readonly cannot!: CannotMethod<Meta>;
 
@@ -204,7 +157,7 @@ export class Guantr<
         >,
       >(
         action: ExtractResourceAction<Meta, ResourceKey>,
-        resource: ResourceKey | [ResourceKey, Resource],
+        resource: [ResourceKey, Resource],
       ) => this._can(action, resource),
       {
         abstract: <ResourceKey extends ExtractResourceKeys<Meta>>(
@@ -223,7 +176,7 @@ export class Guantr<
         >,
       >(
         action: ExtractResourceAction<Meta, ResourceKey>,
-        resource: ResourceKey | [ResourceKey, Resource],
+        resource: [ResourceKey, Resource],
       ) => this._cannot(action, resource),
       {
         abstract: <ResourceKey extends ExtractResourceKeys<Meta>>(
@@ -363,7 +316,7 @@ export class Guantr<
     >,
   >(
     action: ExtractResourceAction<Meta, ResourceKey>,
-    resource: ResourceKey | [ResourceKey, Resource],
+    resource: [ResourceKey, Resource],
   ): Promise<boolean> {
     const context = await this._getContext();
     // Compute serialized context once so it can be reused in both the _can cache key
@@ -372,10 +325,7 @@ export class Guantr<
 
     let cacheKey: string | null = null;
     if (this._storage.cache) {
-      cacheKey =
-        typeof resource === 'string'
-          ? `can/${action}:${resource}:${serializedContext}`
-          : `can/${action}:${resource[0]}:${JSON.stringify(resource[1])}:${serializedContext}`;
+      cacheKey = `can/${action}:${resource[0]}:${JSON.stringify(resource[1])}:${serializedContext}`;
 
       let cachedResult: boolean | undefined = undefined;
       try {
@@ -398,24 +348,6 @@ export class Guantr<
       }
       return result as T;
     };
-
-    if (typeof resource === 'string') {
-      if (Guantr.devWarnings) {
-        const warnKey = `${action as string}:${resource as string}`;
-        if (!Guantr._stringModeWarnedKeys.has(warnKey)) {
-          Guantr._stringModeWarnedKeys.add(warnKey);
-          console.warn(
-            `[guantr] String-mode permission check deprecated: ` +
-              `can/cannot('${action as string}', '${resource as string}'). ` +
-              `This only checks for any allow rule's existence — conditions and deny rules are NOT evaluated. ` +
-              `For abstract checks: use can.abstract() / cannot.abstract(). ` +
-              `For full evaluation: use can/cannot('${action as string}', ['${resource as string}', instance]).`,
-          );
-        }
-      }
-      const rules = await this._storage.queryRules(action as string, resource as string);
-      return await trySetCache(rules.some((item) => item.effect === 'allow'));
-    }
 
     // Retrieve all rules for the given action and resource key & apply condition contextual operand replacement.
     const rawRules = await this._storage.queryRules(action as string, resource[0] as string);
@@ -514,7 +446,7 @@ export class Guantr<
     >,
   >(
     action: ExtractResourceAction<Meta, ResourceKey>,
-    resource: ResourceKey | [ResourceKey, Resource],
+    resource: [ResourceKey, Resource],
   ): Promise<boolean> {
     return !(await this._can(action, resource));
   }

--- a/tests/cannot.test.ts
+++ b/tests/cannot.test.ts
@@ -173,18 +173,11 @@ describe('Guantr.cannot', () => {
       deny('delete', 'post'); // creates unconditional deny rule for delete/post
     });
 
-    // Suppress string-mode deprecation warnings around these assertions
-    const prev = Guantr.devWarnings;
-    Guantr.devWarnings = false;
-    try {
-      // Unconditional allow for read → can() true → cannot() false
-      expect(await guantr.cannot('read', ['post', { id: 1 }])).toBe(false);
+    // Unconditional allow for read → can() true → cannot() false
+    expect(await guantr.cannot('read', ['post', { id: 1 }])).toBe(false);
 
-      // No allow rule for delete (only deny) → can.abstract() false → cannot.abstract() true
-      expect(await guantr.cannot.abstract('delete', 'post')).toBe(true);
-    } finally {
-      Guantr.devWarnings = prev;
-    }
+    // No allow rule for delete (only deny) → can.abstract() false → cannot.abstract() true
+    expect(await guantr.cannot.abstract('delete', 'post')).toBe(true);
   });
 
   // 14. works with the async setRules callback

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -138,7 +138,7 @@ describe('Guantr', () => {
 });
 
 describe('Guantr.can', () => {
-  it('should return true if user has rule', async () => {
+  it('should return true if user has rule (abstract)', async () => {
     const guantr = await createGuantr<MockMeta>();
     await guantr.setRules([
       {
@@ -149,17 +149,17 @@ describe('Guantr.can', () => {
       },
     ]);
 
-    expect(await guantr.can('read', 'post')).toBe(true);
+    expect(await guantr.can.abstract('read', 'post')).toBe(true);
   });
 
-  it('should return false if user does not have rule', async () => {
+  it('should return false if user does not have rule (abstract)', async () => {
     const guantr = await createGuantr<MockMeta>();
     await guantr.setRules([]);
 
-    expect(await guantr.can('read', 'post')).toBe(false);
+    expect(await guantr.can.abstract('read', 'post')).toBe(false);
   });
 
-  it('should return false if resource or action not found in rules', async () => {
+  it('should return false if resource or action not found in rules (abstract)', async () => {
     const guantr = await createGuantr<MockMeta>();
     await guantr.setRules([
       {
@@ -170,10 +170,10 @@ describe('Guantr.can', () => {
       },
     ]);
 
-    expect(await guantr.can('create', 'post')).toBe(false);
+    expect(await guantr.can.abstract('create', 'post')).toBe(false);
   });
 
-  it('should return false if user has inverted rule', async () => {
+  it('should return false if user has inverted rule (abstract)', async () => {
     const guantr = await createGuantr<MockMeta>();
     await guantr.setRules([
       {
@@ -184,7 +184,7 @@ describe('Guantr.can', () => {
       },
     ]);
 
-    expect(await guantr.can('delete', 'post')).toBe(false);
+    expect(await guantr.can.abstract('delete', 'post')).toBe(false);
   });
 
   it('should be able to match condition for nested resource condition', async () => {
@@ -515,7 +515,7 @@ describe('Guantr.can', () => {
       },
     ]);
 
-    expect(await guantr.can('read', 'post')).toBe(true);
+    expect(await guantr.can.abstract('read', 'post')).toBe(true);
     const post = {
       id: 1,
       title: 'Hello World',
@@ -546,7 +546,7 @@ describe('Guantr.can', () => {
       },
     ]);
 
-    expect(await guantr.can('read', 'post')).toBe(true);
+    expect(await guantr.can.abstract('read', 'post')).toBe(true);
     const post = {
       id: 1,
       title: 'Hello World',
@@ -577,7 +577,7 @@ describe('Guantr.can', () => {
       },
     ]);
 
-    expect(await guantr.can('read', 'post')).toBe(true);
+    expect(await guantr.can.abstract('read', 'post')).toBe(true);
     const post = {
       id: 1,
       title: 'Hello World',
@@ -608,7 +608,7 @@ describe('Guantr.can', () => {
       },
     ]);
 
-    expect(await guantr.can('read', 'post')).toBe(true);
+    expect(await guantr.can.abstract('read', 'post')).toBe(true);
     const post = {
       id: 1,
       title: 'Hello World',
@@ -639,7 +639,7 @@ describe('Guantr.can', () => {
       },
     ]);
 
-    expect(await guantr.can('read', 'post')).toBe(false);
+    expect(await guantr.can.abstract('read', 'post')).toBe(false);
     const post = {
       id: 1,
       title: 'Hello World',
@@ -670,7 +670,7 @@ describe('Guantr.can', () => {
       },
     ]);
 
-    expect(await guantr.can('read', 'post')).toBe(false);
+    expect(await guantr.can.abstract('read', 'post')).toBe(false);
     const post = {
       id: 1,
       title: 'Hello World',
@@ -701,7 +701,7 @@ describe('Guantr.can', () => {
       },
     ]);
 
-    expect(await guantr.can('read', 'post')).toBe(true);
+    expect(await guantr.can.abstract('read', 'post')).toBe(true);
     const post = {
       id: 1,
       title: 'Hello World',
@@ -732,7 +732,7 @@ describe('Guantr.can', () => {
       },
     ]);
 
-    expect(await guantr.can('read', 'post')).toBe(true);
+    expect(await guantr.can.abstract('read', 'post')).toBe(true);
     const post = {
       id: 1,
       title: 'Hello World',


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

Closes #83 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

BREAKING CHANGE: the string overload `can(action, 'resource )` and `cannot(action, 'resource')` have been removed. Use `can.abstract()` or `cannot.abstract()` for abstract checks without conditions, or the tuple form `can([key, instance])` / `canno ([key, instance])` for full evaluation.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
