### PR TITLE
refactor(storage)!: make cache.has required

### DIFF
--- a/docs/advanced-usage/caching.md
+++ b/docs/advanced-usage/caching.md
@@ -50,7 +50,7 @@ class LoggingCacheStorage extends InMemoryStorage {
     async has(key: string): Promise<boolean> {
       console.log(`CACHE HAS: Key="${key}"`);
       // Call the original implementation
-      return super.cache.has ? await super.cache.has(key) : false; // Default InMemoryStorage might not have 'has' explicitly separate from get
+      return super.cache.has(key);
     },
 
     async clear(): Promise<void> {
@@ -86,6 +86,18 @@ initialize();
 
 - **Eviction Policies (TTL, LRU):** Guantr itself **does not** implement cache eviction logic like Time-To-Live (TTL) or Least Recently Used (LRU). If you need such policies, they must be implemented within your custom `cache` methods in your storage adapter.
 - **Cache Invalidation:** Be mindful of cache invalidation. If underlying rules or context data changes frequently, a long-lived cache might serve stale permissions. When `setRules` is called, Guantr clears **all** cache entries via `this._storage.cache?.clear()` (see [`Guantr.prototype.setRules` in `src/index.ts`](https://github.com/hrdtr/guantr/blob/main/src/index.ts)). Guantr uses cache keys prefixed with `can/` (for permission check results) and `applyContextualOperands/` (for resolved condition operands). No key-level invalidation is performed — the entire cache is purged on every `setRules` call. External context changes that do not pass through `setRules` might therefore require manual cache clearing via `storage.cache.clear()`, or more granular removal if your adapter supports it.
-- **Interface Compliance:** Ensure your custom `cache` implementation adheres to the method signatures defined in the `Storage['cache']` interface.
+
+## Cache Interface Changes in v2.0
+
+In v2.0, the cache contract was simplified:
+
+- `cache.has` is now **required** when the cache object is provided (no fallback logic).
+- `cache.get` must return `undefined` for cache misses (not `null`).
+
+This eliminates the fragile `has`/`get` fallback branching that was needed in v1.x.
+
+## Important Considerations
+
+- **Interface Compliance:** Ensure your custom `cache` implementation adheres to the method signatures defined in the `Storage['cache']` interface. `has` is now **required** when cache is provided.
 
 By understanding Guantr's caching mechanism and how to customize it via the storage adapter, you can optimize permission check performance for your specific application needs.

--- a/docs/advanced-usage/custom-storage-adapter.md
+++ b/docs/advanced-usage/custom-storage-adapter.md
@@ -8,14 +8,14 @@ To create a custom adapter, you need to implement the `Storage` interface define
 
 **Required Methods:**
 
-- `setRules(rules: GuantrAnyRule[]): Promise<void>`: Replaces all existing rules with the provided array. Should handle storing the rules persistently.
+- `setRules(rules: GuantrAnyRule[]): Promise<void>`: Appends the provided rules to the existing rule set. Guantr always calls `clearRules()` before `setRules()` to achieve replace semantics.
 - `getRules(): Promise<GuantrAnyRule[]>`: Retrieves all currently stored rules.
 - `queryRules(action: string, resource: string): Promise<GuantrAnyRule[]>`: Retrieves only the rules matching a specific action and resource key. Implementing this efficiently (filtering at the source) is crucial for performance with large rule sets.
 - `clearRules(): Promise<void>`: Deletes all stored rules.
 
 **Optional Property:**
 
-- `cache?: { set, get, has, clear }`: An optional object implementing caching logic. See the [Caching Guide](./caching.md) for details.
+- `cache?: { set, get, has, clear }`: An optional object implementing caching logic. If provided, `has` is **required** (no fallback logic; Guantr uses `has` to check cache hits and `get` to retrieve values). `get` must return `undefined` for cache misses. See the [Caching Guide](./caching.md) for details.
 
 ## Example Implementations
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,6 @@ import { GuantrCircuitBreakerError } from './errors';
 import { InMemoryStorage } from './storage';
 import {
   getContextValue,
-  isConditionExpressionLike,
   isContextualOperand,
   matchRuleCondition,
   validateCondition,
@@ -262,11 +261,9 @@ export class Guantr<
     if (this._storage.cache) {
       let cached: ReadonlyArray<GuantrAnyRule> | undefined;
       try {
-        cached = this._storage.cache.has
-          ? (await this._storage.cache.has(cacheKey))
-            ? await this._storage.cache.get<ReadonlyArray<GuantrAnyRule>>(cacheKey)
-            : undefined
-          : await this._storage.cache.get<ReadonlyArray<GuantrAnyRule>>(cacheKey);
+        if (await this._storage.cache.has(cacheKey)) {
+          cached = await this._storage.cache.get<ReadonlyArray<GuantrAnyRule>>(cacheKey);
+        }
       } catch {
         // Swallow cache adapter errors and treat as cache miss
         cached = undefined;
@@ -329,11 +326,9 @@ export class Guantr<
 
       let cachedResult: boolean | undefined = undefined;
       try {
-        cachedResult = this._storage.cache.has
-          ? (await this._storage.cache.has(cacheKey))
-            ? await this._storage.cache.get<boolean>(cacheKey)
-            : undefined
-          : await this._storage.cache.get<boolean>(cacheKey);
+        if (await this._storage.cache.has(cacheKey)) {
+          cachedResult = await this._storage.cache.get<boolean>(cacheKey);
+        }
       } catch {
         // Swallow cache adapter errors and treat as cache miss
         cachedResult = undefined;
@@ -415,11 +410,9 @@ export class Guantr<
       cacheKey = `can.abstract/${action as string}:${resource as string}`;
       let cachedResult: boolean | undefined = undefined;
       try {
-        cachedResult = this._storage.cache.has
-          ? (await this._storage.cache.has(cacheKey))
-            ? await this._storage.cache.get<boolean>(cacheKey)
-            : undefined
-          : await this._storage.cache.get<boolean>(cacheKey);
+        if (await this._storage.cache.has(cacheKey)) {
+          cachedResult = await this._storage.cache.get<boolean>(cacheKey);
+        }
       } catch {
         cachedResult = undefined;
       }
@@ -477,11 +470,9 @@ export class Guantr<
       cacheKey = `applyContextualOperands/${JSON.stringify(condition)}:${serializedCtx}`;
       let cachedResult: GuantrAnyRule['condition'] | undefined = undefined;
       try {
-        cachedResult = this._storage.cache.has
-          ? (await this._storage.cache.has(cacheKey))
-            ? await this._storage.cache.get<GuantrAnyRule['condition']>(cacheKey)
-            : undefined
-          : await this._storage.cache.get<GuantrAnyRule['condition']>(cacheKey);
+        if (await this._storage.cache.has(cacheKey)) {
+          cachedResult = await this._storage.cache.get<GuantrAnyRule['condition']>(cacheKey);
+        }
       } catch {
         // Swallow cache adapter errors and treat as cache miss
         cachedResult = undefined;

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -11,7 +11,8 @@ export class InMemoryStorage implements Storage {
   };
 
   /**
-   * Bulk sets rules by clearing the current index and adding new rules.
+   * Appends rules to the storage index. Guantr always calls `clearRules()` before
+   * `setRules()` to achieve replace semantics.
    * @param rules - Array of rules to set.
    */
   async setRules(rules: GuantrAnyRule[]) {

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -5,11 +5,13 @@ import { GuantrAnyRule } from '../types';
  */
 export interface Storage {
   /**
-   * Appends rules to the storage index. Called after clearRules() by the Guantr class.
-   * @param rule - Array of rules to set.
+   * Sets (appends) rules in the storage index. Guantr calls `clearRules()`
+   * before `setRules()` to achieve replace semantics.
+   *
+   * @param rules - Array of rules to set.
    * @returns A promise that resolves when the rules are set.
    */
-  setRules: (rule: GuantrAnyRule[]) => Promise<void>;
+  setRules: (rules: GuantrAnyRule[]) => Promise<void>;
 
   /**
    * Retrieves all stored rules.
@@ -33,6 +35,7 @@ export interface Storage {
 
   /**
    * Optional cache mechanism for storing and retrieving data.
+   * If provided, `has` is REQUIRED (no fallback logic).
    */
   cache?: {
     /**
@@ -46,19 +49,18 @@ export interface Storage {
     /**
      * Retrieves a value from the cache.
      * @param key - The key associated with the value.
-     * @returns A promise that resolves to the cached value, or undefined if not found.
+     * @returns A promise that resolves to the cached value, or `undefined` if not found.
      */
     get: <T>(key: string) => Promise<T | undefined>;
 
     /**
      * Checks if a key exists in the cache.
+     * Required when the cache object is provided.
      *
      * @param key - The key to check for existence in the cache.
      * @returns A promise that resolves to true if the key exists, false otherwise.
-     * @remarks If implemented, this method is used to check cache hits. If not implemented,
-     * the `get` method is used directly, and it must return `undefined` for cache misses.
      */
-    has?: (key: string) => Promise<boolean>;
+    has: (key: string) => Promise<boolean>;
 
     /**
      * Clears all entries in the cache.


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

Closes #86 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Remove the fallback logic that allowed `cache.has` to be optional. Guantr now strictly calls `has()` to check for cache hits before calling `get()`.

This simplifies internal code paths and aligns the cache interface contract with its usage.

Also fixes the `setRules` documentation and removes an unused import (`isConditionExpressionLike`).

BREAKING CHANGE: The `cache.has` method is now required when providing a custom cache adapter. Guantr no longer falls back to relying solely on `get()` to detect cache misses.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
