### PR TITLE
refactor!: remove Context generic and rename types

### DIFF
--- a/docs/advanced-usage/custom-storage-adapter.md
+++ b/docs/advanced-usage/custom-storage-adapter.md
@@ -8,9 +8,9 @@ To create a custom adapter, you need to implement the `Storage` interface define
 
 **Required Methods:**
 
-- `setRules(rules: GuantrAnyRule[]): Promise<void>`: Atomically replaces all stored rules with the provided rules.
-- `getRules(): Promise<GuantrAnyRule[]>`: Retrieves all currently stored rules.
-- `queryRules(action: string, resource: string): Promise<GuantrAnyRule[]>`: Retrieves only the rules matching a specific action and resource key. Implementing this efficiently (filtering at the source) is crucial for performance with large rule sets.
+- `setRules(rules: GuantrRule[]): Promise<void>`: Atomically replaces all stored rules with the provided rules.
+- `getRules(): Promise<GuantrRule[]>`: Retrieves all currently stored rules.
+- `queryRules(action: string, resource: string): Promise<GuantrRule[]>`: Retrieves only the rules matching a specific action and resource key. Implementing this efficiently (filtering at the source) is crucial for performance with large rule sets.
 
 **Optional Property:**
 
@@ -27,13 +27,13 @@ This adapter is suitable for client-side browser applications where rule persist
 **Note:** LocalStorage has size limits and stores data as strings.
 
 ```ts
-import type { GuantrAnyRule } from 'guantr';
+import type { GuantrRule } from 'guantr';
 import type { Storage } from 'guantr/storage';
 
 const STORAGE_KEY = 'guantr_rules';
 
 class LocalStorageAdapter implements Storage {
-  async setRules(rules: GuantrAnyRule[]): Promise<void> {
+  async setRules(rules: GuantrRule[]): Promise<void> {
     try {
       // Atomically replace the stored rules
       localStorage.setItem(STORAGE_KEY, JSON.stringify(rules));
@@ -43,7 +43,7 @@ class LocalStorageAdapter implements Storage {
     }
   }
 
-  async getRules(): Promise<GuantrAnyRule[]> {
+  async getRules(): Promise<GuantrRule[]> {
     try {
       const storedRules = localStorage.getItem(STORAGE_KEY);
       return storedRules ? JSON.parse(storedRules) : [];
@@ -55,7 +55,7 @@ class LocalStorageAdapter implements Storage {
 
   // Note: This queryRules implementation fetches all rules and filters locally.
   // This can be inefficient for very large rule sets compared to DB filtering.
-  async queryRules(action: string, resource: string): Promise<GuantrAnyRule[]> {
+  async queryRules(action: string, resource: string): Promise<GuantrRule[]> {
     const allRules = await this.getRules();
     return allRules.filter((rule) => rule.action === action && rule.resource === resource);
   }
@@ -69,7 +69,7 @@ class LocalStorageAdapter implements Storage {
 Uses `ioredis` (or a similar client) to store rules in Redis, suitable for shared state between server instances.
 
 ```ts
-import type { GuantrAnyRule } from 'guantr';
+import type { GuantrRule } from 'guantr';
 import type { Storage } from 'guantr/storage';
 import Redis from 'ioredis'; // Assuming ioredis client
 
@@ -77,12 +77,12 @@ const redisClient = new Redis(/* Redis connection options */);
 const REDIS_KEY = 'guantr_rules';
 
 class RedisStorage implements Storage {
-  async setRules(rules: GuantrAnyRule[]): Promise<void> {
+  async setRules(rules: GuantrRule[]): Promise<void> {
     // Atomically replace the stored rules
     await redisClient.set(REDIS_KEY, JSON.stringify(rules));
   }
 
-  async getRules(): Promise<GuantrAnyRule[]> {
+  async getRules(): Promise<GuantrRule[]> {
     const storedRules = await redisClient.get(REDIS_KEY);
     return storedRules ? JSON.parse(storedRules) : [];
   }
@@ -90,7 +90,7 @@ class RedisStorage implements Storage {
   // Note: This queryRules implementation fetches all rules and filters locally.
   // Consider alternative Redis structures (e.g., sets per action/resource)
   // for more efficient querying with very large rule sets.
-  async queryRules(action: string, resource: string): Promise<GuantrAnyRule[]> {
+  async queryRules(action: string, resource: string): Promise<GuantrRule[]> {
     const allRules = await this.getRules();
     return allRules.filter((rule) => rule.action === action && rule.resource === resource);
   }
@@ -132,9 +132,9 @@ const clearStmt = db.prepare('DELETE FROM rules');
 
 // --- Storage Class ---
 class SQLiteStorage implements Storage {
-  async setRules(rules: GuantrAnyRule[]): Promise<void> {
+  async setRules(rules: GuantrRule[]): Promise<void> {
     // Use a transaction for atomic bulk replace
-    db.transaction((ruleList: GuantrAnyRule[]) => {
+    db.transaction((ruleList: GuantrRule[]) => {
       clearStmt.run(); // Clear existing rules first
       for (const rule of ruleList) {
         insertStmt.run(
@@ -147,7 +147,7 @@ class SQLiteStorage implements Storage {
     })(rules);
   }
 
-  async getRules(): Promise<GuantrAnyRule[]> {
+  async getRules(): Promise<GuantrRule[]> {
     const rows = getAllStmt.all() as Array<{
       action: string;
       resource: string;
@@ -160,7 +160,7 @@ class SQLiteStorage implements Storage {
     }));
   }
 
-  async queryRules(action: string, resource: string): Promise<GuantrAnyRule[]> {
+  async queryRules(action: string, resource: string): Promise<GuantrRule[]> {
     // This query efficiently filters at the database level
     const rows = queryStmt.all(action, resource) as Array<{
       action: string;
@@ -197,14 +197,14 @@ model Rule {
 ```
 
 ```ts
-import type { GuantrAnyRule } from 'guantr';
+import type { GuantrRule } from 'guantr';
 import type { Storage } from 'guantr/storage';
 import { PrismaClient, Prisma } from '@prisma/client'; // Import Prisma types if needed
 
 const prisma = new PrismaClient();
 
 class PrismaStorage implements Storage {
-  async setRules(rules: GuantrAnyRule[]): Promise<void> {
+  async setRules(rules: GuantrRule[]): Promise<void> {
     // Use Prisma transaction API for atomicity
     await prisma.$transaction(async (tx) => {
       await tx.rule.deleteMany(); // Clear existing rules
@@ -223,23 +223,23 @@ class PrismaStorage implements Storage {
     });
   }
 
-  async getRules(): Promise<GuantrAnyRule[]> {
+  async getRules(): Promise<GuantrRule[]> {
     const rules = await prisma.rule.findMany();
-    // Map Prisma result to GuantrAnyRule, handling potential null condition
+    // Map Prisma result to GuantrRule, handling potential null condition
     return rules.map((rule) => ({
       ...rule,
-      condition: rule.condition as GuantrAnyRuleCondition | null, // Cast JsonValue back
+      condition: rule.condition as GuantrRuleCondition | null, // Cast JsonValue back
     }));
   }
 
-  async queryRules(action: string, resource: string): Promise<GuantrAnyRule[]> {
+  async queryRules(action: string, resource: string): Promise<GuantrRule[]> {
     // Efficiently filters at the database level
     const rules = await prisma.rule.findMany({
       where: { action, resource },
     });
     return rules.map((rule) => ({
       ...rule,
-      condition: rule.condition as GuantrAnyRuleCondition | null,
+      condition: rule.condition as GuantrRuleCondition | null,
     }));
   }
 

--- a/docs/advanced-usage/rules-as-query-filters/prisma.md
+++ b/docs/advanced-usage/rules-as-query-filters/prisma.md
@@ -11,7 +11,7 @@ You will create a function that accepts an array of rules and produces a Prisma 
 Create a function named `prisma` that accepts a list of rules and produces a Prisma `where` clause.
 
 ```ts
-export const prisma = (rules: GuantrAnyRule[]) => {
+export const prisma = (rules: GuantrRule[]) => {
   const query = {
     OR: [] as Record<string, any>[],
     AND: [] as Record<string, any>[],
@@ -42,16 +42,16 @@ Create a helper `toPrismaWhereClause` to handle the condition object recursively
 
 ```ts
 /**
- * Converts a GuantrAnyPermission condition object to a Prisma where clause.
+ * Converts a GuantrRule condition object to a Prisma where clause.
  *
- * @param {GuantrAnyPermission['condition']} condition - The condition object to convert.
+ * @param {GuantrRule['condition']} condition - The condition object to convert.
  */
-const toPrismaWhereClause = (condition: GuantrAnyPermission['condition']) => {
+const toPrismaWhereClause = (condition: GuantrRule['condition']) => {
   const clause = {} as Record<string, any>;
 
   const processCondition = (
     key: string,
-    nestedConditionOrExpression: GuantrAnyConditionExpression | GuantrAnyCondition,
+    nestedConditionOrExpression: GuantrRuleConditionExpression | GuantrRuleCondition,
   ) => {
     if (isConditionExpressionLike(nestedConditionOrExpression)) {
       const [operator, operand, options] = nestedConditionOrExpression;
@@ -146,7 +146,7 @@ Use this type guard to differentiate condition expressions:
 ```ts
 export const isConditionExpressionLike = (
   maybeExpression: unknown,
-): maybeExpression is GuantrAnyRuleConditionExpression =>
+): maybeExpression is GuantrRuleConditionExpression =>
   Array.isArray(maybeExpression) &&
   maybeExpression.length >= 2 &&
   typeof maybeExpression[0] === 'string';
@@ -179,4 +179,4 @@ const posts = await prisma.post.findFirst({ where });
 - Output types are `Record<string, any>`.
 - Array length filters (e.g. `length[1] < 1`) are only can be interpreted as empty/non-empty checks and currently mapped to `some` or `none`.
 
-This structure gives you full control to enforce rule-based authorization at the database level using Prisma’s native capabilities.
+This structure gives you full control to enforce rule-based authorization at the database level using Prisma's native capabilities.

--- a/docs/api/Guantr/can.md
+++ b/docs/api/Guantr/can.md
@@ -7,7 +7,7 @@ The `can` method checks if a specific action is permitted on a given resource in
 ## Signature
 
 ```ts
-interface Guantr<Meta, Context> {
+interface Guantr<Meta> {
   can(
     action: string, // Or specific action type from Meta
     resource: [resourceKey: string, resourceInstance: object], // Or typed resource key/instance from Meta

--- a/docs/api/Guantr/constructor.md
+++ b/docs/api/Guantr/constructor.md
@@ -12,18 +12,14 @@ import type { GuantrMeta, GuantrOptions } from 'guantr';
 ## Constructor Signature
 
 ```ts
-class Guantr<
-  Meta extends GuantrMeta<GuantrResourceMap> | undefined = undefined,
-  Context extends Record<string, unknown> = Record<string, unknown>,
-> {
-  constructor(options?: GuantrOptions<Context>);
+class Guantr<Meta extends GuantrMeta<GuantrResourceMap> | undefined = undefined> {
+  constructor(options?: GuantrOptions<GuantrContextFromMeta<Meta>>);
 }
 ```
 
 ## Generics
 
-- `Meta`: (Optional) Extends `GuantrMeta`. Provides strong typing for resources, actions, models, and context.
-- `Context`: (Optional) Extends `Record<string, unknown>`. Defines the shape of the context object returned by `getContext`. Defaults to `Record<string, unknown>`.
+- `Meta`: (Optional) Extends `GuantrMeta`. Provides strong typing for resources, actions, models, and context. The `Context` is inferred from `Meta` via `GuantrContextFromMeta<Meta>`.
 
 ## Parameters
 
@@ -34,7 +30,7 @@ class Guantr<
 
 ## Returns
 
-- A `Guantr<Meta, Context>` instance.
+- A `Guantr<Meta>` instance.
 
 ## Comparison with `createGuantr()`
 
@@ -80,7 +76,7 @@ import { MyCustomStorage } from './my-storage-adapter';
 
 type MyContext = { userId: string | null };
 
-const guantr = new Guantr<MyMeta, MyContext>({
+const guantr = new Guantr<MyMeta>({
   storage: new MyCustomStorage(),
   getContext: async () => {
     const user = await getCurrentUser();

--- a/docs/api/Guantr/getRules.md
+++ b/docs/api/Guantr/getRules.md
@@ -5,8 +5,8 @@ The `getRules` method retrieves all permission rules currently registered in the
 ## Signature
 
 ```ts
-interface Guantr<Meta, Context> {
-  getRules(): Promise<ReadonlyArray<GuantrAnyRule>>;
+interface Guantr<Meta> {
+  getRules(): Promise<ReadonlyArray<GuantrRule>>;
 }
 ```
 
@@ -16,7 +16,7 @@ This method takes no parameters.
 
 ## Returns
 
-- `Promise<ReadonlyArray<GuantrAnyRule>>`: A promise that resolves to an array containing all `GuantrAnyRule` objects currently stored by the configured storage adapter. (The returned value is typed as `ReadonlyArray` in TypeScript, but immutability is **not** enforced at runtime — the underlying storage adapter returns a plain mutable `GuantrAnyRule[]` and the array is not frozen. If you require true runtime immutability, clone or `Object.freeze` the array yourself.) The array will be empty if no rules are stored.
+`Promise<ReadonlyArray<GuantrRule>>`: A promise that resolves to an array containing all `GuantrRule` objects currently stored by the configured storage adapter. (The returned value is typed as `ReadonlyArray` in TypeScript, but immutability is **not** enforced at runtime — the underlying storage adapter returns a plain mutable `GuantrRule[]` and the array is not frozen. If you require true runtime immutability, clone or `Object.freeze` the array yourself.)
 
 ## Usage
 

--- a/docs/api/Guantr/relatedRulesFor.md
+++ b/docs/api/Guantr/relatedRulesFor.md
@@ -5,14 +5,14 @@ The `relatedRulesFor` method retrieves all stored permission rules that match a 
 ## Signature
 
 ```ts
-interface Guantr<Meta, Context> {
+interface Guantr<Meta> {
   relatedRulesFor(
     action: string,
     resource: string,
     options?: {
       applyConditionContextualOperands?: boolean;
     },
-  ): Promise<GuantrAnyRule[]>;
+  ): Promise<GuantrRule[]>;
 }
 ```
 
@@ -25,7 +25,7 @@ interface Guantr<Meta, Context> {
 
 ## Returns
 
-- `Promise<GuantrAnyRule[]>`: A promise that resolves to an array containing only the `GuantrAnyRule` objects from storage that exactly match the provided `action` and `resource` key. This array includes both `allow` and `deny` rules matching the criteria. It will be empty if no matching rules are found.
+- `Promise<GuantrRule[]>`: A promise that resolves to an array containing only the `GuantrRule` objects from storage that exactly match the provided `action` and `resource` key. This array includes both `allow` and `deny` rules matching the criteria. It will be empty if no matching rules are found.
 
 ## Usage
 

--- a/docs/api/Guantr/setRules.md
+++ b/docs/api/Guantr/setRules.md
@@ -9,9 +9,9 @@ There are two ways to call `setRules`:
 **1. With a Rules Array:**
 
 ```ts
-interface Guantr<Meta, Context> {
+interface Guantr<Meta> {
   setRules(
-    rules: GuantrRule<Meta, Context>[], // Array of rule objects
+    rules: GuantrRule<Meta>[], // Array of rule objects
   ): Promise<void>;
 }
 ```
@@ -19,21 +19,21 @@ interface Guantr<Meta, Context> {
 **2. With a Callback Function:**
 
 ```ts
-type SetRulesCallback<Meta, Context> = (
+type SetRulesCallback<Meta> = (
   allow: (action: string, resource: string | [resourceKey: string, condition: GuantrRuleCondition<...> | null]) => void,
   deny: (action: string, resource: string | [resourceKey: string, condition: GuantrRuleCondition<...> | null]) => void
 ) => void | Promise<void>;
 
-interface Guantr<Meta, Context> {
+interface Guantr<Meta> {
   setRules(
-    callback: SetRulesCallback<Meta, Context> // Async function defining rules
+    callback: SetRulesCallback<Meta> // Async function defining rules
   ): Promise<void>;
 }
 ```
 
 ## Parameters
 
-- `rules`: (Array Method) An array of `GuantrRule` (or `GuantrAnyRule`) objects. Each object must have `effect` (`'allow'` or `'deny'`), `action` (string), `resource` (string), and optional `condition` (object or null).
+- `rules`: (Array Method) An array of `GuantrRule` (or `GuantrRule`) objects. Each object must have `effect` (`'allow'` or `'deny'`), `action` (string), `resource` (string), and optional `condition` (object or null).
 - `callback`: (Callback Method) An asynchronous function that receives two arguments:
   - `allow`: A function used to define permission grants. Call it as `allow(action, resource)` or `allow(action, [resourceKey, condition])`.
   - `deny`: A function used to define permission restrictions. Call it as `deny(action, resource)` or `deny(action, [resourceKey, condition])`.

--- a/docs/api/createGuantr.md
+++ b/docs/api/createGuantr.md
@@ -15,40 +15,31 @@ import type { GuantrMeta, GuantrRule, GuantrOptions } from 'guantr'; // Import r
 
 ```ts
 // Initialize with options (including context and storage)
-declare function createGuantr<
-  Meta extends GuantrMeta<any> | undefined = undefined,
-  Context extends Record<string, unknown> = Record<string, unknown>,
->(options?: GuantrOptions<Context>): Promise<Guantr<Meta, Context>>;
+declare function createGuantr<Meta extends GuantrMeta<any> | undefined = undefined>(
+  options?: GuantrOptions,
+): Promise<Guantr<Meta>>;
 
 // Initialize with rules array and optionally options
-declare function createGuantr<
-  Meta extends GuantrMeta<any> | undefined = undefined,
-  Context extends Record<string, unknown> = Record<string, unknown>,
->(
-  rules: GuantrRule<Meta, Context>[],
-  options?: GuantrOptions<Context>,
-): Promise<Guantr<Meta, Context>>;
+declare function createGuantr<Meta extends GuantrMeta<any> | undefined = undefined>(
+  rules: GuantrRule<Meta>[],
+  options?: GuantrOptions,
+): Promise<Guantr<Meta>>;
 
 // Initialize with rules callback and optionally options
-declare function createGuantr<
-  Meta extends GuantrMeta<any> | undefined = undefined,
-  Context extends Record<string, unknown> = Record<string, unknown>,
->(
-  setRulesCallback: SetRulesCallback<Meta, Context>,
-  options?: GuantrOptions<Context>,
-): Promise<Guantr<Meta, Context>>;
+declare function createGuantr<Meta extends GuantrMeta<any> | undefined = undefined>(
+  setRulesCallback: SetRulesCallback<Meta>,
+  options?: GuantrOptions,
+): Promise<Guantr<Meta>>;
 
 // Initialize with no arguments (uses defaults)
-declare function createGuantr<
-  Meta extends GuantrMeta<any> | undefined = undefined,
-  Context extends Record<string, unknown> = Record<string, unknown>,
->(): Promise<Guantr<Meta, Context>>;
+declare function createGuantr<Meta extends GuantrMeta<any> | undefined = undefined>(): Promise<
+  Guantr<Meta>
+>;
 ```
 
 ## Generics
 
 - `Meta`: (Optional) Extends `GuantrMeta`. Provides strong typing for resources, actions, models, and context if defined. Enhances type safety during rule definition and checks.
-- `Context`: (Optional) Extends `Record<string, unknown>`. Defines the shape of the context object returned by `getContext`. Defaults to `Record<string, unknown>`.
 
 ## Parameters
 
@@ -63,7 +54,7 @@ declare function createGuantr<
 
 ## Returns
 
-- `Promise<Guantr<Meta, Context>>`: A promise that resolves to a fully initialized `Guantr` instance.
+- `Promise<Guantr<Meta>>`: A promise that resolves to a fully initialized `Guantr` instance.
 
 ## Examples
 
@@ -99,7 +90,7 @@ import { getCurrentUser } from './auth';
 
 type MyContext = { userId: string | null };
 
-const guantrWithOptions = await createGuantr<MyMeta, MyContext>({
+const guantrWithOptions = await createGuantr<MyMeta>({
   storage: new MyCustomStorage(),
   getContext: async () => {
     const user = await getCurrentUser();
@@ -111,7 +102,7 @@ const guantrWithOptions = await createGuantr<MyMeta, MyContext>({
 **With Rules and Options**
 
 ```ts
-const guantrCombo = await createGuantr<MyMeta, MyContext>(
+const guantrCombo = await createGuantr<MyMeta>(
   async (allow, deny) => {
     // Rules callback
     allow('read', 'publicInfo');

--- a/docs/api/error-classes.md
+++ b/docs/api/error-classes.md
@@ -197,10 +197,10 @@ function validateRulesFromDatabase(rules: unknown[]) {
 }
 ```
 
-| Parameter   | Type                         | Description                                                                                             |
-| ----------- | ---------------------------- | ------------------------------------------------------------------------------------------------------- |
-| `condition` | `GuantrAnyRule['condition']` | The condition object to validate (`null` and `undefined` are no-ops).                                   |
-| `_path`     | `string` (optional)          | Dot-notation prefix for error messages. Used internally during recursion; you rarely need to pass this. |
+| Parameter   | Type                      | Description                                                                                             |
+| ----------- | ------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `condition` | `GuantrRule['condition']` | The condition object to validate (`null` and `undefined` are no-ops).                                   |
+| `_path`     | `string` (optional)       | Dot-notation prefix for error messages. Used internally during recursion; you rarely need to pass this. |
 
 ---
 
@@ -254,12 +254,12 @@ See the [`createGuantr`](./createGuantr) API reference for more details.
 
 ```ts
 import { createGuantr, GuantrCircuitBreakerError } from 'guantr';
-import type { GuantrAnyRule } from 'guantr';
+import type { GuantrRule } from 'guantr';
 
 const guantr = await createGuantr({ maxRuleIterations: 100 });
 
 // Create enough rules to trip the breaker
-const rules: GuantrAnyRule[] = [];
+const rules: GuantrRule[] = [];
 for (let i = 0; i < 150; i++) {
   rules.push({
     effect: 'allow',

--- a/docs/api/utilities.md
+++ b/docs/api/utilities.md
@@ -92,16 +92,16 @@ Evaluates a full rule condition object against a model (plain object). This is t
 ```ts
 function matchRuleCondition<Model extends Record<string, unknown>>(
   model: Model,
-  condition: NonNullable<GuantrAnyRule['condition']>,
+  condition: NonNullable<GuantrRule['condition']>,
 ): boolean;
 ```
 
 ### Parameters
 
-| Parameter   | Type                                      | Description                                                                                                          |
-| ----------- | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `model`     | `Model extends Record<string, unknown>`   | The plain object to evaluate the condition against (e.g., a resource instance).                                      |
-| `condition` | `NonNullable<GuantrAnyRule['condition']>` | The condition object from a rule. Each key maps to either a condition expression array or a nested condition object. |
+| Parameter   | Type                                    | Description                                                                                                          |
+| ----------- | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `model`     | `Model extends Record<string, unknown>` | The plain object to evaluate the condition against (e.g., a resource instance).                                      |
+| `condition` | `NonNullable<GuantrRule['condition']>`  | The condition object from a rule. Each key maps to either a condition expression array or a nested condition object. |
 
 ### Returns
 
@@ -116,9 +116,9 @@ function matchRuleCondition<Model extends Record<string, unknown>>(
 
 ```ts
 import { matchRuleCondition } from 'guantr';
-import type { GuantrAnyRuleCondition } from 'guantr';
+import type { GuantrRuleCondition } from 'guantr';
 
-const condition: GuantrAnyRuleCondition = {
+const condition: GuantrRuleCondition = {
   status: ['eq', 'published'],
   author: {
     role: ['in', ['editor', 'admin']],
@@ -159,7 +159,7 @@ Evaluates a single condition expression (a `[operator, operand, ?options]` tuple
 function matchConditionExpression(data: {
   value: unknown;
   expression: Extract<
-    NonNullable<GuantrAnyRule['condition']>[keyof NonNullable<GuantrAnyRule['condition']>],
+    NonNullable<GuantrRule['condition']>[keyof NonNullable<GuantrRule['condition']>],
     Array<any>
   >;
 }): boolean;
@@ -238,7 +238,7 @@ See [Rule Validation](../guides/defining-rules/rule-validation) for a full expla
 ```ts
 function isConditionExpressionLike(
   maybeExpression: unknown,
-): maybeExpression is GuantrAnyRuleConditionExpression;
+): maybeExpression is GuantrRuleConditionExpression;
 ```
 
 ### Parameters
@@ -249,7 +249,7 @@ function isConditionExpressionLike(
 
 ### Returns
 
-- `boolean` — `true` if the value is an array with at least 2 elements and the first element is a string. Acts as a TypeScript type guard, narrowing to `GuantrAnyRuleConditionExpression`.
+- `boolean` — `true` if the value is an array with at least 2 elements and the first element is a string. Acts as a TypeScript type guard, narrowing to `GuantrRuleConditionExpression`.
 
 ### Example
 
@@ -272,15 +272,15 @@ Recursively validates a condition object, throwing `GuantrInvalidConditionError`
 ### Signature
 
 ```ts
-function validateCondition(condition: GuantrAnyRule['condition'], _path?: string): void;
+function validateCondition(condition: GuantrRule['condition'], _path?: string): void;
 ```
 
 ### Parameters
 
-| Parameter   | Type                         | Description                                                                    |
-| ----------- | ---------------------------- | ------------------------------------------------------------------------------ |
-| `condition` | `GuantrAnyRule['condition']` | The condition object to validate. `null` and `undefined` are accepted (no-op). |
-| `_path`     | `string` (optional)          | Dot-notation prefix for error messages. Used internally during recursion.      |
+| Parameter   | Type                      | Description                                                                    |
+| ----------- | ------------------------- | ------------------------------------------------------------------------------ |
+| `condition` | `GuantrRule['condition']` | The condition object to validate. `null` and `undefined` are accepted (no-op). |
+| `_path`     | `string` (optional)       | Dot-notation prefix for error messages. Used internally during recursion.      |
 
 ### Throws
 

--- a/docs/guides/defining-rules.md
+++ b/docs/guides/defining-rules.md
@@ -2,14 +2,14 @@
 
 Rules are the core of Guantr's authorization logic. They define what specific actions users are permitted (`allow`) or explicitly forbidden (`deny`) to perform on resources within your application. Defining these rules accurately, based on the Guantr API, is essential for robust access control.
 
-## The Structure of a Rule (`GuantrAnyRule`)
+## The Structure of a Rule (`GuantrRule`)
 
-Internally, every rule in Guantr follows the `GuantrAnyRule` structure defined in the types:
+Internally, every rule in Guantr follows the `GuantrRule` structure defined in the types:
 
 1.  **`effect`**: `'allow'` | `'deny'` - Determines if the rule grants or revokes permission.
 2.  **`action`**: `string` - The **single** operation being attempted (e.g., `'read'`, `'update'`, `'publish'`).
 3.  **`resource`**: `string` - The _type_ or _key_ identifying the resource (e.g., `'article'`, `'user'`).
-4.  **`condition`**: `GuantrAnyRuleCondition | null` - An optional object specifying conditions that must be met for the rule to apply. This enables attribute-based and context-aware checks. If `null`, the rule applies based only on action and resource type.
+4.  **`condition`**: `GuantrRuleCondition | null` - An optional object specifying conditions that must be met for the rule to apply. This enables attribute-based and context-aware checks. If `null`, the rule applies based only on action and resource type.
 
 ## Methods for Setting Rules
 
@@ -67,11 +67,11 @@ await guantr.setRules((allow, deny) => {
 
 ### 2. Using a Direct Array of Rule Objects
 
-You can also provide an array of rule objects directly to `setRules`. Each object must conform to the `GuantrRule` (or `GuantrAnyRule`) structure. While the callback might be simpler for direct definition, **passing an array provides more flexibility, allowing you to preprocess, generate, or fetch rules from external sources before applying them.**
+You can also provide an array of rule objects directly to `setRules`. Each object must conform to the `GuantrRule` structure. While the callback might be simpler for direct definition, **passing an array provides more flexibility, allowing you to preprocess, generate, or fetch rules from external sources before applying them.**
 
 ```ts
 import { createGuantr } from 'guantr';
-import type { GuantrRule } from 'guantr'; // Or GuantrAnyRule if not using Meta
+import type { GuantrRule } from 'guantr';
 
 const guantr = await createGuantr();
 

--- a/docs/guides/defining-rules/rule-validation.md
+++ b/docs/guides/defining-rules/rule-validation.md
@@ -233,10 +233,10 @@ function validateRulesFromDatabase(rules: unknown[]) {
 
 ### `validateCondition` Reference
 
-| Parameter   | Type                         | Description                                                                    |
-| ----------- | ---------------------------- | ------------------------------------------------------------------------------ |
-| `condition` | `GuantrAnyRule['condition']` | The condition object to validate. `null` and `undefined` are accepted (no-op). |
-| `_path`     | `string` (optional)          | Dot-notation prefix for error messages. Used internally during recursion.      |
+| Parameter   | Type                      | Description                                                                    |
+| ----------- | ------------------------- | ------------------------------------------------------------------------------ |
+| `condition` | `GuantrRule['condition']` | The condition object to validate. `null` and `undefined` are accepted (no-op). |
+| `_path`     | `string` (optional)       | Dot-notation prefix for error messages. Used internally during recursion.      |
 
 **Throws:** `GuantrInvalidConditionError` if the condition contains any malformed expression, unknown operator, or invalid value type.
 

--- a/docs/guides/typescript-integration.md
+++ b/docs/guides/typescript-integration.md
@@ -123,7 +123,7 @@ Pass your defined `Meta` type when creating the Guantr instance and when typing 
 import { createGuantr } from 'guantr';
 // Assumes MyAppMeta is defined as above
 
-const guantr = await createGuantr<MyAppMeta, MyContext>({
+const guantr = await createGuantr<MyAppMeta>({
   getContext: async (): Promise<MyContext> => {
     // Fetch current user data and return object matching MyContext
     const user = await getCurrentUser();
@@ -143,7 +143,7 @@ const guantr = await createGuantr<MyAppMeta, MyContext>({
 import type { GuantrRule } from 'guantr';
 // Assumes MyAppMeta is defined as above
 
-const rules: GuantrRule<MyAppMeta, MyContext>[] = [
+const rules: GuantrRule<MyAppMeta>[] = [
   // TypeScript will validate this rule structure against MyAppMeta
   {
     effect: 'allow',

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -130,7 +130,7 @@ await guantr.setRules(async (allow, deny) => {
 You can also pass an array of rule objects. Remember that the `effect` property should be `'allow'` or `'deny'`, and conditions follow the `[operator, value]` format.
 
 ```ts
-import type { GuantrRule } from 'guantr'; // Or GuantrAnyRule if not using Meta
+import type { GuantrRule } from 'guantr';
 
 // Define types if using TypeScript without Meta for clarity in this example
 type Action = 'read' | 'edit';

--- a/docs/references/glossary.md
+++ b/docs/references/glossary.md
@@ -14,12 +14,12 @@ A string representing the operation a user attempts to perform on a `Resource` (
 
 ## **Condition**
 
-An optional property within a `Rule`. It's an object defining specific criteria that must be met for the rule to apply. Keys correspond to `Resource` model properties, and values are `Condition Expressions`. Conditions enable fine-grained control for ABAC and ReBAC patterns. Defined as `GuantrRuleCondition` / `GuantrAnyRuleCondition`.
+An optional property within a `Rule`. It's an object defining specific criteria that must be met for the rule to apply. Keys correspond to `Resource` model properties, and values are `Condition Expressions`. Conditions enable fine-grained control for ABAC and ReBAC patterns. Defined as `GuantrRuleCondition`.
 
 ## **Condition Expression**
 
 The value associated with a key inside a `Condition` object. It defines the specific comparison logic, typically using an array format
-`[Operator, Operand, Options?]` (e.g., `['eq', 'value']`, `['in', ['a', 'b']]`). Defined as `GuantrAnyRuleConditionExpression`.
+`[Operator, Operand, Options?]` (e.g., `['eq', 'value']`, `['in', ['a', 'b']]`). Defined as `GuantrRuleConditionExpression`.
 
 ## **Context**
 
@@ -59,7 +59,7 @@ The entity or type of entity being acted upon (e.g., an article, a user profile,
 
 ## **Rule**
 
-The fundamental unit defining a permission statement in Guantr. It consists of an `effect` (`'allow'` or `'deny'`), an `action` (string), a `resource` key (string), and an optional `condition` object. Defined as `GuantrRule` / `GuantrAnyRule`. Rules are managed via the `setRules` method.
+The fundamental unit defining a permission statement in Guantr. It consists of an `effect` (`'allow'` or `'deny'`), an `action` (string), a `resource` key (string), and an optional `condition` object. Defined as `GuantrRule`. Rules are managed via the `setRules` method.
 
 ## **Storage**
 

--- a/playground/demos/01-basic.ts
+++ b/playground/demos/01-basic.ts
@@ -1,0 +1,173 @@
+/**
+ * Demo 1: Basic Untyped Usage
+ * ============================
+ *
+ * Demonstrates using Guantr WITHOUT type arguments.
+ * Useful for plain JavaScript projects or quick prototyping.
+ *
+ * TypeScript users get full type safety when no generics are provided:
+ *   - GuantrRule         → { resource: string; action: string; ... }
+ *   - GuantrRuleCondition → { [key: string]: GuantrRuleConditionExpression | ... }
+ *   - GuantrRuleConditionExpression → ['eq', ...] | ['in', ...] | ...
+ */
+
+import {
+  createGuantr,
+  GuantrRule,
+  GuantrRuleCondition,
+  GuantrRuleConditionExpression,
+} from '../../src/index';
+import { heading, sub, assert, info } from '../utils';
+
+export async function demoBasic(): Promise<void> {
+  heading('1. Basic Untyped Usage');
+
+  /* ------------------------------------------------------------------ */
+  /*  1a. Untyped GuantrRule                                              */
+  /* ------------------------------------------------------------------ */
+  sub('GuantrRule without type arguments');
+
+  // When no type arguments are provided, GuantrRule accepts any strings
+  // for `resource` and `action`, and any condition object.
+  const rule: GuantrRule = {
+    effect: 'deny',
+    action: 'delete', // autocomplete: any string
+    resource: 'post', // autocomplete: any string
+    condition: null,
+  };
+  assert(rule.effect === 'deny', 'Untyped GuantrRule accepts plain string action/resource');
+
+  const ruleWithCond: GuantrRule = {
+    effect: 'allow',
+    action: 'read',
+    resource: 'article',
+    condition: {
+      status: ['eq', 'published'],
+      // Nested conditions work too
+      author: { role: ['in', ['editor', 'admin']] },
+    },
+  };
+  assert(ruleWithCond.condition !== null, 'Untyped GuantrRule accepts arbitrary condition');
+
+  /* ------------------------------------------------------------------ */
+  /*  1b. Untyped GuantrRuleCondition                                      */
+  /* ------------------------------------------------------------------ */
+  sub('GuantrRuleCondition without type arguments');
+
+  // Without generics, GuantrRuleCondition is an index-signature type
+  // that accepts any keys with expression or nested condition values.
+  const cond: GuantrRuleCondition = {
+    status: ['eq', 'published'],
+    tags: ['has', 'tech'],
+    nested: {
+      deep: ['gte', 10],
+    },
+  };
+  assert(cond['status']?.[0] === 'eq', 'Untyped condition with eq operator');
+  const nestedDeep = cond.nested as GuantrRuleCondition;
+  assert(
+    Array.isArray(nestedDeep.deep) && nestedDeep.deep[0] === 'gte',
+    'Untyped nested condition resolved',
+  );
+
+  /* ------------------------------------------------------------------ */
+  /*  1c. GuantrRuleConditionExpression                                    */
+  /* ------------------------------------------------------------------ */
+  sub('GuantrRuleConditionExpression');
+
+  // The expression union — usable without any type arguments
+  const exprEq: GuantrRuleConditionExpression = ['eq', 'published'];
+  const exprIn: GuantrRuleConditionExpression = ['in', ['draft', 'published']];
+  const exprGt: GuantrRuleConditionExpression = ['gt', 5];
+  const exprHasSome: GuantrRuleConditionExpression = ['hasSome', ['tag1', 'tag2']];
+
+  assert(exprEq[0] === 'eq', 'Expression eq works');
+  assert(exprIn[0] === 'in', 'Expression in works');
+  assert(exprGt[0] === 'gt', 'Expression gt works');
+  assert(exprHasSome[0] === 'hasSome', 'Expression hasSome works');
+
+  /* ------------------------------------------------------------------ */
+  /*  1d. createGuantr() — no type args                                  */
+  /* ------------------------------------------------------------------ */
+  sub('createGuantr() with no type arguments');
+
+  info('Instantiating Guantr without any generics...');
+
+  const guantr = await createGuantr();
+
+  // setRules with array — all fields are untyped (plain strings)
+  await guantr.setRules([{ effect: 'allow', action: 'read', resource: 'public', condition: null }]);
+
+  assert(await guantr.can('read', ['public', {}]), 'can() works in untyped mode');
+
+  assert(
+    !(await guantr.can('write', ['public', {}])),
+    'can() returns false for undefined permissions',
+  );
+
+  // setRules with callback — same untyped behavior
+  await guantr.setRules((allow, deny) => {
+    allow('read', 'dashboard');
+    deny('delete', ['dashboard', { ownerOnly: ['eq', true] }]);
+  });
+
+  assert(await guantr.can('read', ['dashboard', {}]), 'setRules callback works in untyped mode');
+
+  /* ------------------------------------------------------------------ */
+  /*  1e. Guantr class constructor — no type args                        */
+  /* ------------------------------------------------------------------ */
+  sub('new Guantr() without type arguments');
+
+  const { Guantr } = await import('../../src/index');
+  const g2 = new Guantr();
+
+  await g2.setRules([{ effect: 'allow', action: 'view', resource: 'homepage', condition: null }]);
+
+  assert(await g2.can('view', ['homepage', {}]), 'new Guantr() works in untyped mode');
+
+  /* ------------------------------------------------------------------ */
+  /*  1f. Context usage — untyped still supports $ctx.                   */
+  /* ------------------------------------------------------------------ */
+  sub('Context usage with $ctx. operands (untyped)');
+
+  info('Even without generics, you can use getContext and $ctx. operands.');
+
+  const guantrCtx = await createGuantr({
+    getContext: () => ({ userId: 42, role: 'admin' }),
+  });
+
+  await guantrCtx.setRules([
+    {
+      effect: 'allow',
+      action: 'read',
+      resource: 'document',
+      condition: { ownerId: ['eq', '$ctx.userId'] },
+    },
+    {
+      effect: 'deny',
+      action: 'delete',
+      resource: 'document',
+      condition: { ownerId: ['eq', '$ctx.role'] },
+    },
+  ]);
+
+  assert(
+    await guantrCtx.can('read', ['document', { ownerId: 42 }]),
+    'Untyped $ctx.userId resolves to 42 and matches',
+  );
+
+  assert(
+    !(await guantrCtx.can('read', ['document', { ownerId: 99 }])),
+    'Untyped $ctx.userId resolves to 42, does not match 99',
+  );
+
+  assert(
+    !(await guantrCtx.can('delete', ['document', { ownerId: 'admin' }])),
+    'Untyped $ctx.role resolves to "admin", deny rule matches → denied',
+  );
+
+  /* ------------------------------------------------------------------ */
+  /*  Summary                                                             */
+  /* ------------------------------------------------------------------ */
+  info('Untyped mode complete — all APIs accept plain strings. Context with $ctx. still works.');
+}

--- a/playground/demos/02-typed.ts
+++ b/playground/demos/02-typed.ts
@@ -1,0 +1,230 @@
+/**
+ * Demo 2: Fully Typed Usage
+ * ==========================
+ *
+ * Demonstrates using Guantr with GuantrMeta for full type safety.
+ *
+ * Key v2.0 patterns:
+ *   - Context is part of GuantrMeta, NOT a separate generic
+ *   - createGuantr<MyMeta>()  — no Context generic needed
+ *   - GuantrRule<MyMeta>      — infers resource keys, actions, condition shapes
+ *   - GuantrRuleCondition     — untyped when no Model; typed with Model
+ *   - $ctx. autocompletion   — Context leaf keys appear in condition operands
+ */
+
+import type { Post, User, BlogContext } from '../utils';
+import {
+  createGuantr,
+  GuantrMeta,
+  GuantrResourceMap,
+  GuantrRule,
+  GuantrRuleCondition,
+} from '../../src/index';
+import { heading, sub, assert, info } from '../utils';
+
+/* ------------------------------------------------------------------ */
+/*  Blog Resource Map & Meta                                            */
+/* ------------------------------------------------------------------ */
+
+type BlogResourceMap = GuantrResourceMap<{
+  post: {
+    action: 'create' | 'read' | 'update' | 'delete' | 'publish';
+    model: Post;
+  };
+  user: {
+    action: 'read' | 'update' | 'delete' | 'ban';
+    model: User;
+  };
+  comment: {
+    action: 'create' | 'read' | 'moderate' | 'delete';
+    model: {
+      id: number;
+      postId: number;
+      userId: number;
+      text: string;
+      flagged: boolean;
+      moderated: boolean;
+    };
+  };
+}>;
+
+/**
+ * BlogMeta includes BlogContext directly.
+ * v2.0: Context is NO LONGER a separate generic on createGuantr.
+ */
+type BlogMeta = GuantrMeta<BlogResourceMap, BlogContext>;
+
+/* ------------------------------------------------------------------ */
+/*  Helper to create a fully-typed guantr instance                      */
+/* ------------------------------------------------------------------ */
+
+function createBlogGuantr(ctx: BlogContext) {
+  return createGuantr<BlogMeta>({
+    getContext: () => ctx,
+  });
+}
+
+/* ------------------------------------------------------------------ */
+/*  Demo                                                                */
+/* ------------------------------------------------------------------ */
+
+export async function demoTyped(): Promise<void> {
+  heading('2. Fully Typed Usage');
+
+  /* ------------------------------------------------------------------ */
+  /*  2a. GuantrRule<BlogMeta>                                           */
+  /* ------------------------------------------------------------------ */
+  // ┌─────────────────────────────────────────────────────────────┐
+  // │  TYPE COMPLETION CHECKPOINT — GuantrRule<BlogMeta>          │
+  // │                                                             │
+  // │  Type the object literal below. Your IDE should autocomplete:│
+  // │  resource  → 'post' | 'user' | 'comment'                    │
+  // │  action    → narrowed after choosing resource               │
+  // │              - post:  'create'|'read'|'update'|'delete'|'pub'│
+  // │              - user:  'read'|'update'|'delete'|'ban'        │
+  // │              - comment: 'create'|'read'|'moderate'|'delete' │
+  // │  condition → GuantrRuleCondition<Post, BlogContext>         │
+  // │              keys are Post model fields                     │
+  // │              $ctx. shows BlogContext leaf keys              │
+  // └─────────────────────────────────────────────────────────────┘
+  sub('GuantrRule<BlogMeta> — narrowed resource & action');
+
+  const typedRule: GuantrRule<BlogMeta> = {
+    effect: 'allow',
+    resource: 'post',
+    action: 'publish',
+    condition: { authorId: ['eq', '$ctx.userId'] },
+  };
+  assert(typedRule.resource === 'post', 'Typed GuantrRule<BlogMeta> constrains resource keys');
+
+  /* ------------------------------------------------------------------ */
+  /*  2b. GuantrRuleCondition<Model, Context>                             */
+  /* ------------------------------------------------------------------ */
+  // ┌─────────────────────────────────────────────────────────────┐
+  // │  TYPE COMPLETION CHECKPOINT — GuantrRuleCondition<Post,    │
+  // │                                    BlogContext>            │
+  // │                                                             │
+  // │  When typing condition keys, autocomplete shows Post fields:│
+  // │  id (number)    → NumberConditionExpression                 │
+  // │  title (string) → StringConditionExpression                 │
+  // │  status (union) → StringConditionExpression (literals)      │
+  // │  tags (string[]) → ArrayConditionExpressionBasic            │
+  // │  metadata (obj) → nested GuantrRuleCondition                │
+  // │  comments (array of obj) → ArrayConditionExpressionObject   │
+  // │                                                             │
+  // │  At operand positions ($ctx.), autocomplete shows           │
+  // │  BlogContext leaf keys:                                     │
+  // │  $ctx.userId, $ctx.userRole, $ctx.isAuthenticated,          │
+  // │  $ctx.teamId                                                │
+  // └─────────────────────────────────────────────────────────────┘
+  sub('GuantrRuleCondition<Post, BlogContext> — typed condition');
+
+  const typedCond: GuantrRuleCondition<Post, BlogContext> = {
+    status: ['eq', 'published'],
+    authorId: ['eq', '$ctx.userId'],
+    tags: ['has', 'typescript'],
+    metadata: {
+      views: ['gte', 100],
+      featured: ['eq', true],
+    },
+  };
+  assert(typedCond.status?.[0] === 'eq', 'Typed condition: status eq');
+  const md = typedCond.metadata as GuantrRuleCondition;
+  assert(Array.isArray(md.views) && md.views[0] === 'gte', 'Typed condition: metadata.views gte');
+
+  /* ------------------------------------------------------------------ */
+  /*  2c. GuantrRuleCondition without generics → untyped fallback         */
+  /* ------------------------------------------------------------------ */
+  sub('GuantrRuleCondition (no generics) — untyped fallback');
+
+  const untypedCond: GuantrRuleCondition = {
+    anyKey: ['eq', 'anyValue'],
+    deeply: { nested: { path: ['gt', 1] } },
+  };
+  assert(untypedCond.anyKey?.[0] === 'eq', 'Untyped condition fallback works');
+
+  /* ------------------------------------------------------------------ */
+  /*  2d. createGuantr<BlogMeta>() — Context inferred from Meta           */
+  /* ------------------------------------------------------------------ */
+  // ┌─────────────────────────────────────────────────────────────┐
+  // │  TYPE COMPLETION CHECKPOINT — createGuantr<BlogMeta>()     │
+  // │                                                             │
+  // │  Only ONE type argument is accepted now:                    │
+  // │  ✅ createGuantr<BlogMeta>(...)  — Context from Meta        │
+  // │  ❌ createGuantr<BlogMeta, BlogContext>(...)  — ERROR       │
+  // │                                                             │
+  // │  Hover over `guantr` below — its type is:                   │
+  // │  Guantr<BlogMeta>                                            │
+  // │  (NOT Guantr<BlogMeta, BlogContext>)                        │
+  // └─────────────────────────────────────────────────────────────┘
+  sub('createGuantr<BlogMeta>() — Context inferred, not passed as generic');
+
+  const guantr = await createBlogGuantr({
+    userId: 1,
+    userRole: 'editor',
+    isAuthenticated: true,
+  });
+
+  await guantr.setRules(async (allow, deny) => {
+    // Autocomplete: 'action' is narrowed per 'resource'
+    // Autocomplete: 'resource' is 'post' | 'user' | 'comment'
+    allow('read', 'post');
+    allow('update', ['post', { authorId: ['eq', '$ctx.userId'] }]);
+
+    deny('delete', ['post', { status: ['eq', 'published'] }]);
+    deny('delete', ['comment', { flagged: ['eq', true] }]);
+  });
+
+  const post: Post = {
+    id: 10,
+    title: 'Test',
+    content: '...',
+    status: 'published',
+    authorId: 1,
+    tags: [],
+    metadata: { views: 0, featured: false, category: '' },
+    comments: [],
+  };
+
+  assert(await guantr.can('read', ['post', post]), 'Typed: can read any post');
+  assert(
+    !(await guantr.can('delete', ['post', post])),
+    'Typed: deny overrides allow for published post',
+  );
+
+  /* ------------------------------------------------------------------ */
+  /*  2e. Type inference in can/cannot calls                              */
+  /* ------------------------------------------------------------------ */
+  // ┌─────────────────────────────────────────────────────────────┐
+  // │  TYPE COMPLETION CHECKPOINT — can() type inference          │
+  // │                                                             │
+  // │  Type `guantr.can(` and your IDE should show:               │
+  // │  - First arg: action narrowed by resource                   │
+  // │  - Second arg: ['post', PostInstance]                       │
+  // │               The PostInstance is typed (not `any`)         │
+  // │                                                             │
+  // │  Type `guantr.can.abstract(` and your IDE should show:      │
+  // │  - First arg: action narrowed by resource                   │
+  // │  - Second arg: resource key (string, no instance)           │
+  // └─────────────────────────────────────────────────────────────┘
+  sub('can() / cannot() — type inference from resource key');
+
+  await guantr.can('update', [
+    'post',
+    {
+      id: 1,
+      title: '',
+      content: '',
+      status: 'draft',
+      authorId: 1,
+      tags: [],
+      metadata: { views: 0, featured: false, category: '' },
+      comments: [],
+    },
+  ]);
+
+  /* ------------------------------------------------------------------ */
+  /*  Summary                                                             */
+  /* ------------------------------------------------------------------ */
+  info('Typed mode complete — Meta fully drives type inference.');
+}

--- a/playground/demos/03-operators.ts
+++ b/playground/demos/03-operators.ts
@@ -1,0 +1,171 @@
+/**
+ * Demo 3: All Condition Operators
+ * ================================
+ *
+ * Demonstrates every condition operator at runtime via matchRuleCondition.
+ * Also covers case-insensitive options, nullish expressions, $expr with
+ * length checks, and nested object conditions.
+ */
+
+import { matchRuleCondition, KNOWN_OPERATORS } from '../../src/index';
+import { heading, sub, assert, info } from '../utils';
+
+export async function demoOperators(): Promise<void> {
+  heading('3. Condition Operators');
+
+  const model = {
+    title: 'Hello World',
+    status: 'published',
+    tags: ['news', 'tech', 'typescript'],
+    count: 42,
+    ratio: 3.14,
+    active: true,
+    nested: { value: 10 },
+    optional: null,
+    missing: undefined,
+  };
+
+  /* ------------------------------------------------------------------ */
+  /*  3a. String operators                                                */
+  /* ------------------------------------------------------------------ */
+  sub('String operators: eq, in, contains, startsWith, endsWith');
+
+  assert(matchRuleCondition(model, { title: ['eq', 'Hello World'] }), 'eq string');
+  assert(matchRuleCondition(model, { status: ['in', ['draft', 'published']] }), 'in string');
+  assert(matchRuleCondition(model, { title: ['contains', 'World'] }), 'contains');
+  assert(matchRuleCondition(model, { title: ['startsWith', 'Hello'] }), 'startsWith');
+  assert(matchRuleCondition(model, { title: ['endsWith', 'World'] }), 'endsWith');
+
+  // Negative cases
+  assert(!matchRuleCondition(model, { title: ['eq', 'Goodbye'] }), 'eq negative');
+  assert(!matchRuleCondition(model, { status: ['in', ['draft', 'archived']] }), 'in negative');
+  assert(!matchRuleCondition(model, { title: ['contains', 'xyz'] }), 'contains negative');
+
+  /* ------------------------------------------------------------------ */
+  /*  3b. Numeric operators                                               */
+  /* ------------------------------------------------------------------ */
+  sub('Numeric operators: eq, in, gt, gte');
+
+  assert(matchRuleCondition(model, { count: ['eq', 42] }), 'eq number');
+  assert(matchRuleCondition(model, { count: ['in', [10, 42, 100]] }), 'in number');
+  assert(matchRuleCondition(model, { count: ['gt', 10] }), 'gt');
+  assert(matchRuleCondition(model, { count: ['gte', 42] }), 'gte');
+  assert(matchRuleCondition(model, { ratio: ['gt', 3] }), 'gt float');
+  assert(matchRuleCondition(model, { ratio: ['gte', 3.14] }), 'gte float');
+
+  // Negative cases
+  assert(!matchRuleCondition(model, { count: ['gt', 100] }), 'gt negative');
+  assert(!matchRuleCondition(model, { count: ['eq', 0] }), 'eq number negative');
+
+  /* ------------------------------------------------------------------ */
+  /*  3c. Boolean operator                                                */
+  /* ------------------------------------------------------------------ */
+  sub('Boolean operator: eq');
+
+  assert(matchRuleCondition(model, { active: ['eq', true] }), 'eq boolean true');
+  assert(!matchRuleCondition(model, { active: ['eq', false] }), 'eq boolean false negative');
+
+  /* ------------------------------------------------------------------ */
+  /*  3d. Nullish operator                                                */
+  /* ------------------------------------------------------------------ */
+  sub('Nullish operator: eq');
+
+  assert(matchRuleCondition({ value: null }, { value: ['eq', null] }), 'eq null');
+  assert(matchRuleCondition({ value: undefined }, { value: ['eq', undefined] }), 'eq undefined');
+
+  /* ------------------------------------------------------------------ */
+  /*  3e. Array primitive operators                                       */
+  /* ------------------------------------------------------------------ */
+  sub('Array operators: has, hasSome, hasEvery');
+
+  assert(matchRuleCondition(model, { tags: ['has', 'tech'] }), 'has');
+  assert(matchRuleCondition(model, { tags: ['hasSome', ['news', 'sports']] }), 'hasSome');
+  assert(matchRuleCondition(model, { tags: ['hasEvery', ['news', 'tech']] }), 'hasEvery');
+  assert(!matchRuleCondition(model, { tags: ['has', 'sports'] }), 'has negative');
+  assert(
+    !matchRuleCondition(model, { tags: ['hasSome', ['sports', 'music']] }),
+    'hasSome negative',
+  );
+  assert(
+    !matchRuleCondition(model, { tags: ['hasEvery', ['news', 'tech', 'music']] }),
+    'hasEvery negative',
+  );
+
+  /* ------------------------------------------------------------------ */
+  /*  3f. Case-insensitive option                                         */
+  /* ------------------------------------------------------------------ */
+  sub('Case-insensitive option');
+
+  assert(
+    matchRuleCondition(model, { title: ['eq', 'hello world', { caseInsensitive: true }] }),
+    'eq case-insensitive',
+  );
+  assert(
+    matchRuleCondition(model, { tags: ['has', 'TYPESCRIPT', { caseInsensitive: true }] }),
+    'has case-insensitive',
+  );
+  assert(
+    matchRuleCondition(model, { title: ['contains', 'world', { caseInsensitive: true }] }),
+    'contains case-insensitive',
+  );
+  assert(
+    matchRuleCondition(model, { title: ['startsWith', 'hello', { caseInsensitive: true }] }),
+    'startsWith case-insensitive',
+  );
+
+  /* ------------------------------------------------------------------ */
+  /*  3g. Nested condition objects                                        */
+  /* ------------------------------------------------------------------ */
+  sub('Nested condition objects');
+
+  assert(matchRuleCondition(model, { nested: { value: ['gte', 5] } }), 'Nested object condition');
+  assert(
+    !matchRuleCondition(model, { nested: { value: ['eq', 100] } }),
+    'Nested object condition negative',
+  );
+
+  /* ------------------------------------------------------------------ */
+  /*  3h. Null/undefined model values                                     */
+  /* ------------------------------------------------------------------ */
+  sub('Edge cases: null/undefined model values');
+
+  assert(
+    !matchRuleCondition({ title: null }, { title: ['eq', 'anything'] }),
+    'null model value returns false',
+  );
+  assert(
+    !matchRuleCondition({ title: undefined }, { title: ['eq', 'anything'] }),
+    'undefined model value returns false',
+  );
+
+  /* ------------------------------------------------------------------ */
+  /*  3i. KNOWN_OPERATORS export                                          */
+  /* ------------------------------------------------------------------ */
+  sub('KNOWN_OPERATORS set');
+
+  const expected = [
+    'eq',
+    'in',
+    'contains',
+    'startsWith',
+    'endsWith',
+    'gt',
+    'gte',
+    'has',
+    'hasSome',
+    'hasEvery',
+    'some',
+    'every',
+    'none',
+  ] as const;
+
+  for (const op of expected) {
+    assert(KNOWN_OPERATORS.has(op), `KNOWN_OPERATORS includes '${op}'`);
+  }
+  assert(KNOWN_OPERATORS.size === expected.length, 'No unknown operators in set');
+
+  /* ------------------------------------------------------------------ */
+  /*  Summary                                                             */
+  /* ------------------------------------------------------------------ */
+  info('All condition operators verified.');
+}

--- a/playground/demos/04-context.ts
+++ b/playground/demos/04-context.ts
@@ -1,0 +1,294 @@
+/**
+ * Demo 4: Context-Aware Rules
+ * ============================
+ *
+ * Demonstrates $ctx. operands — how rules can reference context values
+ * that are resolved at evaluation time.
+ *
+ * Also covers:
+ *   - can / cannot / can.abstract / cannot.abstract
+ *   - Rule lifecycle: setRules (array + callback), getRules, relatedRulesFor
+ *   - Condition validation at definition time
+ */
+
+import type { Post, BlogContext } from '../utils';
+import { createGuantr, GuantrMeta, GuantrResourceMap, validateCondition } from '../../src/index';
+import { heading, sub, assert, info } from '../utils';
+import { publishedPost } from '../utils';
+
+/* ------------------------------------------------------------------ */
+/*  Typed context demo                                                  */
+/* ------------------------------------------------------------------ */
+
+type CtxResourceMap = GuantrResourceMap<{
+  post: {
+    action: 'read' | 'update' | 'delete' | 'publish';
+    model: Post;
+  };
+}>;
+
+type CtxMeta = GuantrMeta<CtxResourceMap, BlogContext>;
+
+export async function demoContext(): Promise<void> {
+  heading('4. Context-Aware Rules ($ctx.)');
+
+  /* ------------------------------------------------------------------ */
+  /*  4a. Context with leaf-key autocompletion                           */
+  /* ------------------------------------------------------------------ */
+  // ┌─────────────────────────────────────────────────────────────┐
+  // │  TYPE COMPLETION CHECKPOINT — $ctx. autocompletion          │
+  // │                                                             │
+  // │  CtxMeta = GuantrMeta<..., BlogContext>                     │
+  // │  BlogContext = { userId, userRole, isAuthenticated, teamId?}│
+  // │                                                             │
+  // │  When typing `$ctx.` inside condition operands, you should  │
+  // │  see these autocompletions:                                 │
+  // │                                                             │
+  // │  $ctx.userId            (number)                            │
+  // │  $ctx.userRole          ('admin'|'editor'|'viewer')         │
+  // │  $ctx.isAuthenticated   (boolean)                           │
+  // │  $ctx.teamId            (number|undefined)  ← optional      │
+  // │                                                             │
+  // │  The type of operand is narrowed by the operator:           │
+  // │  - ['eq', $ctx.…]   shows matching type context paths      │
+  // │  - ['gt', $ctx.…]   shows only number paths                │
+  // │  - ['has', $ctx.…]  shows only array paths                 │
+  // └─────────────────────────────────────────────────────────────┘
+  sub('$ctx. operands — autocompleted from BlogContext');
+
+  const guantr = await createGuantr<CtxMeta>({
+    getContext: () => ({
+      userId: 42,
+      userRole: 'editor',
+      isAuthenticated: true,
+    }),
+  });
+
+  await guantr.setRules([
+    {
+      effect: 'allow',
+      action: 'update',
+      resource: 'post',
+      condition: { authorId: ['eq', '$ctx.userId'] },
+    },
+    // Published posts can be read
+    {
+      effect: 'allow',
+      action: 'read',
+      resource: 'post',
+      condition: { status: ['eq', 'published'] },
+    },
+  ]);
+
+  // Same author — should match $ctx.userId === 42
+  assert(
+    await guantr.can('update', ['post', { ...publishedPost(), authorId: 42 }]),
+    '$ctx.userId resolves and matches authorId',
+  );
+
+  // Different author — should NOT match
+  assert(
+    !(await guantr.can('update', ['post', { ...publishedPost(), authorId: 99 }])),
+    '$ctx.userId does not match different authorId',
+  );
+
+  /* ------------------------------------------------------------------ */
+  /*  4b. Nullable context properties                                     */
+  /* ------------------------------------------------------------------ */
+  sub('Nullable context ($ctx.teamId)');
+
+  const guantrWithOptional = await createGuantr<CtxMeta>({
+    getContext: () => ({
+      userId: 1,
+      userRole: 'admin',
+      isAuthenticated: true,
+      teamId: 1, // teamId is optional but sometimes set
+    }),
+  });
+
+  await guantrWithOptional.setRules([
+    {
+      effect: 'allow',
+      action: 'read',
+      resource: 'post',
+      // teamId is optional (BlogContext.teamId?: number).
+      // When present, $ctx.teamId resolves to its value (1).
+      condition: { authorId: ['eq', '$ctx.teamId'] },
+    },
+  ]);
+
+  assert(
+    await guantrWithOptional.can('read', ['post', { ...publishedPost(), authorId: 1 }]),
+    'Optional context property ($ctx.teamId) resolves when set',
+  );
+
+  assert(
+    !(await guantrWithOptional.can('read', ['post', { ...publishedPost(), authorId: 99 }])),
+    'Optional context property ($ctx.teamId) does not match if present but different',
+  );
+
+  // ┌─────────────────────────────────────────────────────────────┐
+  // │  TYPE COMPLETION CHECKPOINT — can() / cannot() signatures    │
+  // │                                                             │
+  // │  When typing `g.can(`, your IDE should show:                 │
+  // │    can<ResourceKey, Resource>(                              │
+  // │      action: ResourceMap[ResourceKey]['action'],            │
+  // │      resource: [ResourceKey, Resource],                     │
+  // │    ): Promise<boolean>                                      │
+  // │                                                             │
+  // │  When typing `g.can.abstract(`, your IDE should show:       │
+  // │    can.abstract<ResourceKey>(                               │
+  // │      action: ResourceMap[ResourceKey]['action'],            │
+  // │      resource: ResourceKey,                                  │
+  // │    ): Promise<boolean>                                      │
+  // │                                                             │
+  // │  Same patterns for `g.cannot` and `g.cannot.abstract`.      │
+  // └─────────────────────────────────────────────────────────────┘
+  /* ------------------------------------------------------------------ */
+  /*  4c. can / cannot / abstract methods                                 */
+  /* ------------------------------------------------------------------ */
+  sub('can(), cannot(), can.abstract(), cannot.abstract()');
+
+  const g = await createGuantr<CtxMeta>({
+    getContext: () => ({ userId: 1, userRole: 'admin', isAuthenticated: true }),
+  });
+
+  await g.setRules([
+    { effect: 'allow', action: 'read', resource: 'post', condition: null },
+    {
+      effect: 'deny',
+      action: 'delete',
+      resource: 'post',
+      condition: { status: ['eq', 'published'] },
+    },
+    {
+      effect: 'allow',
+      action: 'delete',
+      resource: 'post',
+      condition: { authorId: ['eq', '$ctx.userId'] },
+    },
+  ]);
+
+  // can() — full evaluation
+  assert(await g.can('read', ['post', publishedPost()]), 'can() returns true for allowed action');
+  assert(
+    !(await g.can('delete', ['post', publishedPost()])),
+    'can() returns false when deny overrides',
+  );
+
+  // cannot() — negation
+  assert(await g.cannot('delete', ['post', publishedPost()]), 'cannot() negates can()');
+  assert(
+    !(await g.cannot('read', ['post', publishedPost()])),
+    'cannot() returns false for allowed action',
+  );
+
+  // can.abstract() — ignores conditions and deny rules
+  assert(await g.can.abstract('delete', 'post'), 'can.abstract() true when any allow rule exists');
+  assert(
+    !(await g.can.abstract('publish', 'post')),
+    'can.abstract() false when no allow rule exists',
+  );
+
+  // cannot.abstract() — negated abstract
+  assert(
+    await g.cannot.abstract('publish', 'post'),
+    'cannot.abstract() true when no allow rule exists',
+  );
+  assert(
+    !(await g.cannot.abstract('read', 'post')),
+    'cannot.abstract() false when allow rule exists',
+  );
+
+  /* ------------------------------------------------------------------ */
+  /*  4d. Rule lifecycle                                                  */
+  /* ------------------------------------------------------------------ */
+  sub('Rule lifecycle: setRules / getRules / relatedRulesFor');
+
+  const lifecycle = await createGuantr<CtxMeta>();
+
+  // setRules with array
+  await lifecycle.setRules([
+    { effect: 'allow', action: 'read', resource: 'post', condition: null },
+    {
+      effect: 'deny',
+      action: 'delete',
+      resource: 'post',
+      condition: { status: ['eq', 'archived'] },
+    },
+  ]);
+  assert(
+    (await lifecycle.getRules()).length === 2,
+    'getRules returns 2 rules after setRules(array)',
+  );
+
+  // setRules with callback (replaces all rules)
+  await lifecycle.setRules(async (allow) => {
+    allow('read', 'post');
+    allow('read', ['post', { status: ['eq', 'published'] }]);
+  });
+  assert(
+    (await lifecycle.getRules()).length === 2,
+    'getRules returns 2 rules after callback setRules',
+  );
+
+  // relatedRulesFor — filters by action + resource
+  const filtered = await lifecycle.relatedRulesFor('read', 'post');
+  assert(filtered.length === 2, 'relatedRulesFor filters by action+resource');
+  assert(
+    filtered.every((r) => r.action === 'read' && r.resource === 'post'),
+    'All returned rules match',
+  );
+
+  // relatedRulesFor with contextual operand resolution
+  const ctxGuantr = await createGuantr<CtxMeta>({
+    getContext: () => ({ userId: 1, userRole: 'admin', isAuthenticated: true }),
+  });
+  await ctxGuantr.setRules([
+    {
+      effect: 'allow',
+      action: 'read',
+      resource: 'post',
+      condition: { authorId: ['eq', '$ctx.userId'] },
+    },
+  ]);
+
+  const resolved = await ctxGuantr.relatedRulesFor('read', 'post', {
+    applyConditionContextualOperands: true,
+  });
+  assert(resolved.length === 1, 'relatedRulesFor with contextual operands returns 1 rule');
+  assert(
+    JSON.stringify(resolved[0].condition).includes('1'),
+    '$ctx.userId resolved to 1 in condition',
+  );
+
+  /* ------------------------------------------------------------------ */
+  /*  4e. Condition validation                                            */
+  /* ------------------------------------------------------------------ */
+  sub('Condition validation at definition time');
+
+  // Valid conditions — should not throw
+  validateCondition(null);
+  validateCondition({ status: ['eq', 'published'] });
+  validateCondition({ tags: ['hasSome', ['a', 'b']] });
+  validateCondition({
+    items: ['some', { price: ['gte', 10] }],
+  });
+  assert(true, 'validateCondition accepts valid conditions');
+
+  // Invalid conditions — should throw
+  try {
+    // Intentionally passing an invalid operator to test runtime validation
+    validateCondition({ bad: ['unknown_op', 'val'] } as unknown as Parameters<
+      typeof validateCondition
+    >[0]);
+    assert(false, 'Should have thrown for unknown operator');
+  } catch {
+    assert(true, 'validateCondition rejects unknown operator');
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  Summary                                                             */
+  /* ------------------------------------------------------------------ */
+  info('Context usage and lifecycle verified.');
+}

--- a/playground/demos/05-array-operators.ts
+++ b/playground/demos/05-array-operators.ts
@@ -1,0 +1,344 @@
+/**
+ * Demo 5: Array Operators (some / every / none / $expr)
+ * =====================================================
+ *
+ * Demonstrates object-array operators and $expr (length + expression).
+ */
+
+import { createGuantr, matchRuleCondition, GuantrMeta, GuantrResourceMap } from '../../src/index';
+import { heading, sub, assert, info } from '../utils';
+
+/* ------------------------------------------------------------------ */
+/*  Typed resource maps for end-to-end $expr demos                    */
+/* ------------------------------------------------------------------ */
+
+/** Model with primitive array — used by $expr + has/length demo */
+type TaggedPost = {
+  id: number;
+  tags: string[];
+};
+
+/** Model with object array — used by $expr + some/length demo */
+type CommentedPost = {
+  id: number;
+  comments: Array<{
+    id: number;
+    text: string;
+    moderated: boolean;
+  }>;
+};
+
+type ExprResourceMap = GuantrResourceMap<{
+  post: { action: 'read'; model: TaggedPost };
+  article: { action: 'read'; model: CommentedPost };
+}>;
+
+type ExprMeta = GuantrMeta<ExprResourceMap>;
+
+export async function demoArrayOperators(): Promise<void> {
+  heading('5. Array Operators (some / every / none / $expr)');
+
+  /* ------------------------------------------------------------------ */
+  /*  5a. some — at least one element matches                             */
+  /* ------------------------------------------------------------------ */
+  sub('some — at least one element matches the nested condition');
+
+  const article = {
+    comments: [
+      { id: 1, text: 'Great post!', moderated: true },
+      { id: 2, text: 'Spam comment', moderated: false },
+      { id: 3, text: 'Nice work', moderated: true },
+    ],
+  };
+
+  assert(
+    matchRuleCondition(article, {
+      comments: ['some', { moderated: ['eq', false] }],
+    }),
+    'some: at least one unmoderated comment exists',
+  );
+
+  assert(
+    matchRuleCondition(article, {
+      comments: ['some', { text: ['contains', 'Spam'] }],
+    }),
+    'some: at least one comment contains "Spam"',
+  );
+
+  assert(
+    !matchRuleCondition(article, {
+      comments: ['some', { text: ['eq', 'nonexistent'] }],
+    }),
+    'some: no comment matches nonexistent text',
+  );
+
+  /* ------------------------------------------------------------------ */
+  /*  5b. every — all elements must match                                 */
+  /* ------------------------------------------------------------------ */
+  sub('every — all elements must match the nested condition');
+
+  assert(
+    !matchRuleCondition(article, {
+      comments: ['every', { moderated: ['eq', true] }],
+    }),
+    'every: not all comments are moderated (one is false)',
+  );
+
+  // All comments should have non-empty text
+  assert(
+    matchRuleCondition(article, {
+      comments: ['every', { text: ['startsWith', ''] }],
+    }),
+    'every: all texts start with empty string (always true)',
+  );
+
+  /* ------------------------------------------------------------------ */
+  /*  5c. none — no elements should match                                 */
+  /* ------------------------------------------------------------------ */
+  sub('none — no elements must match the nested condition');
+
+  assert(
+    matchRuleCondition(article, {
+      comments: ['none', { text: ['eq', 'nonexistent'] }],
+    }),
+    'none: no comment matches "nonexistent"',
+  );
+
+  assert(
+    !matchRuleCondition(article, {
+      comments: ['none', { moderated: ['eq', false] }],
+    }),
+    'none: there IS an unmoderated comment, so none([moderated=false]) is false',
+  );
+
+  /* ------------------------------------------------------------------ */
+  /*  5d. some with multiple nested conditions                            */
+  /* ------------------------------------------------------------------ */
+  sub('some with multiple conditions in the nested condition');
+
+  assert(
+    matchRuleCondition(article, {
+      comments: ['some', { moderated: ['eq', true], text: ['contains', 'Great'] }],
+    }),
+    'some: moderated comment containing "Great"',
+  );
+
+  assert(
+    !matchRuleCondition(article, {
+      comments: ['some', { moderated: ['eq', true], text: ['contains', 'Spam'] }],
+    }),
+    'some: no moderated comment contains "Spam"',
+  );
+
+  /* ------------------------------------------------------------------ */
+  /*  5e. $expr — combine length check with array expression              */
+  /* ------------------------------------------------------------------ */
+  sub('$expr — combining length with array expression');
+
+  const model = {
+    tags: ['news', 'tech', 'typescript'],
+  };
+
+  assert(
+    matchRuleCondition(model, {
+      tags: { $expr: ['has', 'tech'], length: ['gte', 2] },
+    }),
+    '$expr: length >= 2 AND has "tech"',
+  );
+
+  assert(
+    !matchRuleCondition(model, {
+      tags: { $expr: ['has', 'sports'], length: ['gte', 2] },
+    }),
+    '$expr: length >= 2 but does NOT have "sports"',
+  );
+
+  assert(
+    !matchRuleCondition(model, {
+      tags: { $expr: ['has', 'news'], length: ['eq', 1] },
+    }),
+    '$expr: has "news" but length is not 1',
+  );
+
+  // ── End-to-end: $expr + length in an actual rule ──
+  // ┌─────────────────────────────────────────────────────────────┐
+  // │  TYPE COMPLETION CHECKPOINT — typed $expr + length         │
+  // │                                                             │
+  // │  Using createGuantr<ExprMeta>() — tags is string[],         │
+  // │  autocomplete suggests ['has', <string>], ['hasSome', ...], │
+  // │  and { $expr: ..., length: ... } for arrays.               │
+  // │  The operand of `has` is narrowed to string.                │
+  // └─────────────────────────────────────────────────────────────┘
+  sub('End-to-end: setRules with $expr + length');
+
+  const guantrExpr = await createGuantr<ExprMeta>();
+  await guantrExpr.setRules([
+    {
+      effect: 'allow',
+      action: 'read',
+      resource: 'post',
+      condition: {
+        tags: { $expr: ['has', 'typescript'], length: ['gte', 2] },
+      },
+    },
+  ]);
+
+  assert(
+    await guantrExpr.can('read', ['post', { id: 1, tags: ['typescript', 'javascript', 'react'] }]),
+    '$expr rule: post with typescript AND length >= 2 → allowed',
+  );
+
+  assert(
+    !(await guantrExpr.can('read', ['post', { id: 2, tags: ['typescript'] }])),
+    '$expr rule: post with typescript but length 1 < 2 → denied',
+  );
+
+  assert(
+    !(await guantrExpr.can('read', ['post', { id: 3, tags: ['javascript', 'react'] }])),
+    '$expr rule: post without typescript but length >= 2 → denied',
+  );
+
+  // ── End-to-end: $expr + length on array of objects ──
+  // ┌─────────────────────────────────────────────────────────────┐
+  // │  TYPE COMPLETION CHECKPOINT — typed $expr on object array  │
+  // │                                                             │
+  // │  comments is Array<{ id, text, moderated }>.                │
+  // │  Autocomplete offers:                                       │
+  // │    ['some', { moderated: ['eq', <boolean>] }]   ← boolean!  │
+  // │    { $expr: ['some', ...], length: ['gte', <number>] }     │
+  // │                                                             │
+  // │  `moderated` typed as boolean → operand narrowed to boolean.│
+  // │  Passing a string (e.g. `['eq', 'string']`) is a TS error. │
+  // └─────────────────────────────────────────────────────────────┘
+  sub('$expr + length on object arrays (some + length)');
+
+  const guantrObjExpr = await createGuantr<ExprMeta>();
+  await guantrObjExpr.setRules([
+    {
+      effect: 'allow',
+      action: 'read',
+      resource: 'article',
+      // Only allow reading articles that have AT LEAST 2 moderated comments.
+      // `moderated` is typed as boolean — autocomplete suggests true/false,
+      // and passing a string like `['eq', 'string']` would be a TS error.
+      condition: {
+        comments: {
+          $expr: ['some', { moderated: ['eq', true] }],
+          length: ['gte', 2],
+        },
+      },
+    },
+  ]);
+
+  assert(
+    await guantrObjExpr.can('read', [
+      'article',
+      {
+        id: 1,
+        comments: [
+          { id: 1, text: 'Great!', moderated: true },
+          { id: 2, text: 'Nice', moderated: true },
+          { id: 3, text: 'Spam', moderated: false },
+        ],
+      },
+    ]),
+    '$expr object array: 3 comments, 2 moderated, length >= 2 → allowed',
+  );
+
+  assert(
+    !(await guantrObjExpr.can('read', [
+      'article',
+      {
+        id: 2,
+        comments: [
+          { id: 1, text: 'Spam', moderated: false },
+          { id: 2, text: 'Spam2', moderated: false },
+        ],
+      },
+    ])),
+    '$expr object array: 2 comments, 0 moderated, some fails → denied',
+  );
+
+  assert(
+    !(await guantrObjExpr.can('read', [
+      'article',
+      {
+        id: 3,
+        comments: [{ id: 1, text: 'Great!', moderated: true }],
+      },
+    ])),
+    '$expr object array: 1 comment, 1 moderated, length < 2 → denied',
+  );
+
+  /* ------------------------------------------------------------------ */
+  /*  5f. Deeply nested some                                             */
+  /* ------------------------------------------------------------------ */
+  sub('Deeply nested some inside some');
+
+  const complex = {
+    groups: [
+      {
+        name: 'admins',
+        users: [
+          { id: 1, active: true },
+          { id: 2, active: false },
+        ],
+      },
+      {
+        name: 'editors',
+        users: [{ id: 3, active: true }],
+      },
+    ],
+  };
+
+  assert(
+    matchRuleCondition(complex, {
+      groups: [
+        'some',
+        {
+          name: ['eq', 'admins'],
+          users: ['some', { id: ['eq', 1] }],
+        },
+      ],
+    }),
+    'some with nested some: admins group contains user id=1',
+  );
+
+  assert(
+    !matchRuleCondition(complex, {
+      groups: [
+        'some',
+        {
+          name: ['eq', 'admins'],
+          users: ['every', { active: ['eq', true] }],
+        },
+      ],
+    }),
+    'some with nested every: not all admins users are active',
+  );
+
+  /* ------------------------------------------------------------------ */
+  /*  5g. Empty arrays                                                    */
+  /* ------------------------------------------------------------------ */
+  sub('Edge cases: empty arrays');
+
+  const empty = { items: [] as Array<Record<string, unknown>> };
+
+  assert(
+    !matchRuleCondition(empty, { items: ['some', { x: ['eq', 1] }] }),
+    'some on empty array returns false',
+  );
+  assert(
+    !matchRuleCondition(empty, { items: ['every', { x: ['eq', 1] }] }),
+    'every on empty array returns false (no matching items)',
+  );
+  assert(
+    matchRuleCondition(empty, { items: ['none', { x: ['eq', 1] }] }),
+    'none on empty array returns true',
+  );
+
+  /* ------------------------------------------------------------------ */
+  /*  Summary                                                             */
+  /* ------------------------------------------------------------------ */
+  info('Array operators verified — some, every, none, $expr.');
+}

--- a/playground/demos/06-storage.ts
+++ b/playground/demos/06-storage.ts
@@ -1,0 +1,203 @@
+/**
+ * Demo 6: Custom Storage Adapter
+ * ===============================
+ *
+ * Demonstrates implementing the Storage interface for custom backends.
+ * Covers array-based storage, cache integration, and error handling.
+ */
+
+import type { Storage } from '../../src/storage/types';
+import { createGuantr, Guantr, GuantrRule, GuantrMeta, GuantrResourceMap } from '../../src/index';
+import { InMemoryStorage } from '../../src/storage';
+import { heading, sub, assert, assertRejects, info } from '../utils';
+
+/* ------------------------------------------------------------------ */
+/*  Typed resource map for storage demos                               */
+/* ------------------------------------------------------------------ */
+
+type StorageResourceMap = GuantrResourceMap<{
+  post: {
+    action: 'read' | 'delete' | 'view';
+    model: { id: number };
+  };
+  dashboard: {
+    action: 'view';
+    model: Record<string, unknown>;
+  };
+  reports: {
+    action: 'read';
+    model: Record<string, unknown>;
+  };
+}>;
+
+type StorageMeta = GuantrMeta<StorageResourceMap>;
+
+/* ------------------------------------------------------------------ */
+/*  6a. Custom array-based storage (no cache)                           */
+/* ------------------------------------------------------------------ */
+
+class ArrayStorage implements Storage {
+  private _rules: GuantrRule[] = [];
+
+  async setRules(rules: GuantrRule[]): Promise<void> {
+    this._rules = [...rules];
+  }
+
+  async getRules(): Promise<GuantrRule[]> {
+    return [...this._rules];
+  }
+
+  async queryRules(action: string, resource: string): Promise<GuantrRule[]> {
+    return this._rules.filter((r) => r.action === action && r.resource === resource);
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/*  6b. Custom storage with cache                                      */
+/* ------------------------------------------------------------------ */
+
+class CachedArrayStorage implements Storage {
+  private _rules: GuantrRule[] = [];
+  private _cache = new Map<string, unknown>();
+
+  async setRules(rules: GuantrRule[]): Promise<void> {
+    this._rules = [...rules];
+    this._cache.clear(); // Invalidate cache on rule change
+  }
+
+  async getRules(): Promise<GuantrRule[]> {
+    return [...this._rules];
+  }
+
+  async queryRules(action: string, resource: string): Promise<GuantrRule[]> {
+    return this._rules.filter((r) => r.action === action && r.resource === resource);
+  }
+
+  cache = {
+    set: async <T>(key: string, value: T) => {
+      this._cache.set(key, value);
+    },
+    get: async <T>(key: string): Promise<T | undefined> => this._cache.get(key) as T | undefined,
+    has: async (key: string) => this._cache.has(key),
+    clear: async () => {
+      this._cache.clear();
+    },
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Demo                                                                */
+/* ------------------------------------------------------------------ */
+
+export async function demoStorage(): Promise<void> {
+  heading('6. Custom Storage Adapter');
+
+  /* ------------------------------------------------------------------ */
+  /*  6c. Basic array storage                                             */
+  /* ------------------------------------------------------------------ */
+  sub('ArrayStorage (no cache)');
+
+  const guantr = await createGuantr<StorageMeta>({ storage: new ArrayStorage() });
+
+  await guantr.setRules([
+    { effect: 'allow', action: 'read', resource: 'post', condition: null },
+    { effect: 'deny', action: 'delete', resource: 'post', condition: null },
+  ]);
+
+  assert(await guantr.can('read', ['post', { id: 1 }]), 'Custom storage (no cache): can() works');
+  assert(
+    !(await guantr.can('delete', ['post', { id: 1 }])),
+    'Custom storage (no cache): deny overrides allow',
+  );
+
+  /* ------------------------------------------------------------------ */
+  /*  6d. InMemoryStorage (built-in) with cache                           */
+  /* ------------------------------------------------------------------ */
+  sub('InMemoryStorage (built-in, with cache)');
+
+  const guantr2 = await createGuantr<StorageMeta>({ storage: new InMemoryStorage() });
+
+  await guantr2.setRules([{ effect: 'allow', action: 'read', resource: 'post', condition: null }]);
+
+  // First call — populates cache
+  assert(await guantr2.can('read', ['post', { id: 1 }]), 'InMemoryStorage: first call works');
+
+  // Second call — serves from cache
+  assert(await guantr2.can('read', ['post', { id: 2 }]), 'InMemoryStorage: subsequent call works');
+
+  // getRules
+  const stored = await guantr2.getRules();
+  assert(stored.length === 1, 'InMemoryStorage: getRules returns stored rules');
+
+  /* ------------------------------------------------------------------ */
+  /*  6e. CachedArrayStorage                                              */
+  /* ------------------------------------------------------------------ */
+  sub('CachedArrayStorage');
+
+  const cachedStorage = new CachedArrayStorage();
+  const guantr3 = await createGuantr<StorageMeta>({ storage: cachedStorage });
+
+  await guantr3.setRules([
+    { effect: 'allow', action: 'view', resource: 'dashboard', condition: null },
+  ]);
+
+  assert(await guantr3.can('view', ['dashboard', {}]), 'CachedArrayStorage: can() works');
+
+  // setRules should invalidate cache
+  await guantr3.setRules([
+    { effect: 'allow', action: 'view', resource: 'dashboard', condition: null },
+    { effect: 'deny', action: 'view', resource: 'dashboard', condition: null },
+  ]);
+
+  assert(
+    !(await guantr3.can('view', ['dashboard', {}])),
+    'CachedArrayStorage: cache invalidated after setRules',
+  );
+
+  /* ------------------------------------------------------------------ */
+  /*  6f. Circuit breaker with custom storage                             */
+  /* ------------------------------------------------------------------ */
+  sub('Circuit breaker with custom storage');
+
+  const breakerGuantr = await createGuantr<StorageMeta>({
+    storage: new InMemoryStorage(),
+    maxRuleIterations: 50,
+  });
+
+  // Create 51 rules — exceed the limit
+  const manyRules: GuantrRule<StorageMeta>[] = [];
+  for (let i = 0; i < 51; i++) {
+    manyRules.push({
+      effect: 'allow',
+      action: 'read',
+      resource: 'post',
+      condition: { id: ['eq', i] },
+    });
+  }
+  await breakerGuantr.setRules(manyRules);
+
+  await assertRejects(
+    () => breakerGuantr.can('read', ['post', { id: 999 }]),
+    'Circuit breaker trips when iteration limit exceeded',
+  );
+
+  /* ------------------------------------------------------------------ */
+  /*  6g. Create Guantr with options only (no rules)                     */
+  /* ------------------------------------------------------------------ */
+  sub('new Guantr(options) — direct constructor');
+
+  const direct = new Guantr<StorageMeta>({ storage: new InMemoryStorage() });
+  await direct.setRules([
+    { effect: 'allow', action: 'read', resource: 'reports', condition: null },
+  ]);
+
+  assert(
+    await direct.can('read', ['reports', {}]),
+    'new Guantr(options) works with custom storage',
+  );
+
+  /* ------------------------------------------------------------------ */
+  /*  Summary                                                             */
+  /* ------------------------------------------------------------------ */
+  info('Custom storage and circuit breaker verified.');
+}

--- a/playground/demos/07-advanced.ts
+++ b/playground/demos/07-advanced.ts
@@ -1,0 +1,403 @@
+/**
+ * Demo 7: Advanced Real-World Scenarios
+ * ======================================
+ *
+ * Covers:
+ *   - Full RBAC (Role-Based Access Control) with admin, editor, viewer roles
+ *   - Multi-tenant isolation
+ *   - Content moderation workflow
+ *   - Complex nested conditions with depth 3+
+ *   - Condition validation errors
+ *   - Utility function exports (isContextualOperand, isConditionExpressionLike)
+ */
+
+import type { Post, BlogContext } from '../utils';
+import {
+  createGuantr,
+  GuantrMeta,
+  GuantrResourceMap,
+  GuantrCircuitBreakerError,
+  GuantrInvalidConditionError,
+  GuantrInvalidConditionOperatorError,
+  matchRuleCondition,
+  isConditionExpressionLike,
+  isContextualOperand,
+} from '../../src/index';
+import { heading, sub, assert, info } from '../utils';
+import { publishedPost, draftPost } from '../utils';
+
+/* ================================================================== */
+/*  SCENARIO A: Full Blog RBAC                                          */
+/* ================================================================== */
+
+type RbacResourceMap = GuantrResourceMap<{
+  post: { action: 'create' | 'read' | 'update' | 'delete' | 'publish'; model: Post };
+}>;
+
+type RbacMeta = GuantrMeta<RbacResourceMap, BlogContext>;
+
+async function scenarioRBAC(): Promise<void> {
+  sub('Scenario A: Blog RBAC (admin vs editor vs viewer)');
+
+  async function buildGuantr(ctx: BlogContext) {
+    const g = await createGuantr<RbacMeta>({ getContext: () => ctx });
+
+    await g.setRules([
+      // ── Level 1: Base permissions (everyone) ──
+      {
+        effect: 'allow',
+        action: 'read',
+        resource: 'post',
+        condition: { status: ['eq', 'published'] },
+      },
+      { effect: 'allow', action: 'create', resource: 'post', condition: null },
+
+      // ── Level 2: Editor permissions ──
+      {
+        effect: 'allow',
+        action: 'publish',
+        resource: 'post',
+        condition: { status: ['eq', 'published'] },
+      },
+      { effect: 'allow', action: 'update', resource: 'post', condition: null },
+
+      // ── Level 3: Admin permissions (overrides) ──
+      {
+        effect: 'allow',
+        action: 'delete',
+        resource: 'post',
+        condition: { authorId: ['eq', '$ctx.userId'] },
+      },
+
+      // ── Deny rules (always win) ──
+      {
+        effect: 'deny',
+        action: 'delete',
+        resource: 'post',
+        condition: { status: ['eq', 'published'] },
+      },
+      {
+        effect: 'deny',
+        action: 'publish',
+        resource: 'post',
+        condition: { status: ['eq', 'draft'] },
+      },
+    ]);
+
+    return g;
+  }
+
+  const admins = await buildGuantr({ userId: 1, userRole: 'admin', isAuthenticated: true });
+  const editors = await buildGuantr({ userId: 2, userRole: 'editor', isAuthenticated: true });
+
+  const pub = publishedPost();
+  const draft = draftPost();
+
+  // Admin assertions
+  assert(await admins.can('read', ['post', pub]), 'RBAC: admin can read published');
+  assert(await admins.can('create', ['post', draft]), 'RBAC: admin can create');
+  assert(
+    !(await admins.can('delete', ['post', pub])),
+    'RBAC: admin cannot delete published (deny override)',
+  );
+  assert(await admins.can('publish', ['post', pub]), 'RBAC: admin can publish published');
+
+  // Editor assertions
+  assert(await editors.can('read', ['post', pub]), 'RBAC: editor can read published');
+  assert(await editors.can('publish', ['post', pub]), 'RBAC: editor can publish');
+  assert(!(await editors.can('delete', ['post', pub])), 'RBAC: editor cannot delete published');
+}
+
+/* ================================================================== */
+/*  SCENARIO B: Multi-Tenant CMS                                        */
+/* ================================================================== */
+
+type TenantContext = {
+  userId: number;
+  tenantId: number;
+  role: 'owner' | 'admin' | 'member';
+};
+
+type TenantResourceMap = GuantrResourceMap<{
+  project: {
+    action: 'read' | 'update' | 'delete' | 'invite';
+    model: {
+      id: number;
+      tenantId: number;
+      name: string;
+      ownerId: number;
+      members: Array<{ userId: number; role: string }>;
+    };
+  };
+  document: {
+    action: 'read' | 'create' | 'update' | 'delete';
+    model: { id: number; projectId: number; title: string; content: string; createdBy: number };
+  };
+}>;
+
+type TenantMeta = GuantrMeta<TenantResourceMap, TenantContext>;
+
+async function scenarioMultiTenant(): Promise<void> {
+  sub('Scenario B: Multi-Tenant CMS');
+
+  const guantr = await createGuantr<TenantMeta>({
+    getContext: () => ({ userId: 1, tenantId: 5, role: 'owner' }),
+  });
+
+  await guantr.setRules([
+    // Tenant isolation: users can only access projects in their tenant
+    {
+      effect: 'allow',
+      action: 'read',
+      resource: 'project',
+      condition: { tenantId: ['eq', '$ctx.tenantId'] },
+    },
+    // Owner can delete own project
+    {
+      effect: 'allow',
+      action: 'delete',
+      resource: 'project',
+      condition: { ownerId: ['eq', '$ctx.userId'], tenantId: ['eq', '$ctx.tenantId'] },
+    },
+    // Members can read documents in tenant projects
+    { effect: 'allow', action: 'read', resource: 'document', condition: null },
+  ]);
+
+  const myProject = { id: 1, tenantId: 5, name: 'My Project', ownerId: 1, members: [] };
+  const otherProject = { id: 2, tenantId: 99, name: 'Other', ownerId: 2, members: [] };
+
+  assert(
+    await guantr.can('read', ['project', myProject]),
+    'Multi-tenant: user can read project in their tenant',
+  );
+  assert(
+    !(await guantr.can('read', ['project', otherProject])),
+    'Multi-tenant: user cannot read other tenant project',
+  );
+  assert(
+    await guantr.can('delete', ['project', myProject]),
+    'Multi-tenant: owner can delete own project',
+  );
+}
+
+/* ================================================================== */
+/*  SCENARIO C: Content Moderation                                      */
+/* ================================================================== */
+
+type ModContext = {
+  moderatorId: number;
+  canDelete: boolean;
+};
+
+type ModResourceMap = GuantrResourceMap<{
+  comment: {
+    action: 'read' | 'approve' | 'reject' | 'delete';
+    model: {
+      id: number;
+      text: string;
+      flagged: boolean;
+      reports: number;
+      authorReputation: number;
+      tags: string[];
+    };
+  };
+}>;
+
+type ModMeta = GuantrMeta<ModResourceMap, ModContext>;
+
+async function scenarioModeration(): Promise<void> {
+  sub('Scenario C: Content Moderation');
+
+  const guantr = await createGuantr<ModMeta>({
+    getContext: () => ({ moderatorId: 1, canDelete: true }),
+  });
+
+  await guantr.setRules([
+    // Auto-approve trusted authors
+    {
+      effect: 'allow',
+      action: 'approve',
+      resource: 'comment',
+      condition: { authorReputation: ['gte', 100] },
+    },
+    // Flagged comments with high reports need review
+    {
+      effect: 'allow',
+      action: 'read',
+      resource: 'comment',
+      condition: { flagged: ['eq', true], reports: ['gte', 3] },
+    },
+    // Delete only if allowed by context and comment is flagged
+    {
+      effect: 'allow',
+      action: 'delete',
+      resource: 'comment',
+      condition: { flagged: ['eq', true], tags: ['has', 'spam'] },
+    },
+    // Deny approving high-report comments
+    { effect: 'deny', action: 'approve', resource: 'comment', condition: { reports: ['gte', 10] } },
+  ]);
+
+  const spamComment = {
+    id: 1,
+    text: 'Buy now!',
+    flagged: true,
+    reports: 5,
+    authorReputation: 1,
+    tags: ['spam', 'promo'],
+  };
+  const trustedComment = {
+    id: 2,
+    text: 'Great article',
+    flagged: false,
+    reports: 0,
+    authorReputation: 200,
+    tags: [],
+  };
+
+  assert(
+    await guantr.can('read', ['comment', spamComment]),
+    'Moderation: can read flagged+reported comment',
+  );
+  assert(
+    await guantr.can('approve', ['comment', trustedComment]),
+    'Moderation: can auto-approve trusted author',
+  );
+  assert(
+    !(await guantr.can('approve', ['comment', spamComment])),
+    'Moderation: cannot approve reported+flagged comment',
+  );
+  assert(
+    await guantr.can('delete', ['comment', spamComment]),
+    'Moderation: can delete spam comment',
+  );
+}
+
+/* ================================================================== */
+/*  SCENARIO D: Complex Nested Conditions (Depth 3+)                    */
+/* ================================================================== */
+
+async function scenarioDeepNested(): Promise<void> {
+  sub('Scenario D: Deeply nested conditions (depth 3+)');
+
+  const deepModel = {
+    level1: {
+      level2: {
+        level3: {
+          value: 'deeply-nested',
+          numbers: [1, 2, 3],
+        },
+      },
+    },
+  };
+
+  assert(
+    matchRuleCondition(deepModel, {
+      level1: { level2: { level3: { value: ['eq', 'deeply-nested'] } } },
+    }),
+    '3-level deep nested condition matches',
+  );
+
+  assert(
+    !matchRuleCondition(deepModel, {
+      level1: { level2: { level3: { value: ['eq', 'wrong'] } } },
+    }),
+    '3-level deep nested condition rejects wrong value',
+  );
+
+  // Deep $expr
+  assert(
+    matchRuleCondition(deepModel, {
+      level1: { level2: { level3: { numbers: { $expr: ['has', 2], length: ['gte', 2] } } } },
+    }),
+    '3-level deep $expr combined with length check',
+  );
+
+  // Mixed: some with deep nesting
+  const nestedSome = {
+    departments: [
+      {
+        name: 'engineering',
+        teams: [
+          { name: 'frontend', members: [{ id: 1, skills: ['ts', 'react'] }] },
+          { name: 'backend', members: [{ id: 2, skills: ['ts', 'node'] }] },
+        ],
+      },
+    ],
+  };
+
+  assert(
+    matchRuleCondition(nestedSome, {
+      departments: [
+        'some',
+        {
+          name: ['eq', 'engineering'],
+          teams: [
+            'some',
+            {
+              name: ['eq', 'frontend'],
+              members: ['some', { skills: ['has', 'react'] }],
+            },
+          ],
+        },
+      ],
+    }),
+    '4-level nested some: engineering > frontend > member with react skill',
+  );
+}
+
+/* ================================================================== */
+/*  SCENARIO E: Utility Exports                                         */
+/* ================================================================== */
+
+async function scenarioUtilities(): Promise<void> {
+  sub('Scenario E: Exported utilities');
+
+  // isConditionExpressionLike
+  assert(isConditionExpressionLike(['eq', 'val']), 'isConditionExpressionLike: detects valid expr');
+  assert(isConditionExpressionLike(['in', ['a', 'b']]), 'isConditionExpressionLike: array operand');
+  assert(!isConditionExpressionLike('not array'), 'isConditionExpressionLike: rejects non-array');
+  assert(!isConditionExpressionLike(['only']), 'isConditionExpressionLike: rejects short array');
+  assert(
+    !isConditionExpressionLike([1, 'val']),
+    'isConditionExpressionLike: rejects non-string operator',
+  );
+
+  // isContextualOperand
+  assert(isContextualOperand('$ctx.userId'), 'isContextualOperand: detects $ctx prefix');
+  assert(
+    isContextualOperand('$ctx.deeply.nested.value'),
+    'isContextualOperand: detects nested $ctx path',
+  );
+  assert(!isContextualOperand('userId'), 'isContextualOperand: rejects non-$ctx string');
+  // Intentionally passing a non-string to test runtime branch
+  assert(!isContextualOperand(42 as unknown as string), 'isContextualOperand: rejects non-string');
+
+  // Error classes
+  const cbError = new GuantrCircuitBreakerError('read', 'post', 100);
+  assert(cbError.action === 'read', 'GuantrCircuitBreakerError: action');
+  assert(cbError.resource === 'post', 'GuantrCircuitBreakerError: resource');
+  assert(cbError.limit === 100, 'GuantrCircuitBreakerError: limit');
+
+  const icError = new GuantrInvalidConditionError({ bad: 'value' }, 'test reason');
+  assert(icError.reason === 'test reason', 'GuantrInvalidConditionError: reason');
+
+  const icoError = new GuantrInvalidConditionOperatorError('badOp');
+  assert(icoError.operator === 'badOp', 'GuantrInvalidConditionOperatorError: operator');
+}
+
+/* ================================================================== */
+/*  Main                                                                */
+/* ================================================================== */
+
+export async function demoAdvanced(): Promise<void> {
+  heading('7. Advanced Real-World Scenarios');
+
+  await scenarioRBAC();
+  await scenarioMultiTenant();
+  await scenarioModeration();
+  await scenarioDeepNested();
+  await scenarioUtilities();
+
+  info('All advanced scenarios completed.');
+}

--- a/playground/demos/08-complex-context.ts
+++ b/playground/demos/08-complex-context.ts
@@ -1,0 +1,743 @@
+/**
+ * Demo 8: Complex Nested Context
+ * ===============================
+ *
+ * Demonstrates $ctx. autocompletion with deeply nested context shapes:
+ *   - Nested objects         → $ctx.organization.department.name
+ *   - Nullable nested paths  → $ctx.organization?.billing.plan.tier
+ *   - Arrays in context      → $ctx.roles (string[])
+ *   - Array of objects       → $ctx.teams (array of team objects)
+ *   - Mixed deep nesting     → $ctx.organization.billing.plan.features
+ *
+ * The LeafKeys type recursively traverses the Context and exposes leaf
+ * paths with the $ctx. prefix. Only nullable intermediate nodes get a ?
+ * suffix (e.g. $ctx.contact?.address?.city, $ctx.organization?.billing.email).
+ */
+
+import { createGuantr, GuantrMeta, GuantrResourceMap } from '../../src/index';
+import { heading, sub, assert, info } from '../utils';
+
+/* ================================================================== */
+/*  Complex Context Type                                                */
+/* ================================================================== */
+
+/**
+ * =====================================================================
+ *  TYPE COMPLETION CHECKPOINT — EnterpriseContext
+ * =====================================================================
+ *
+ * This type models a realistic enterprise context.  Hover over any
+ * `$ctx.…` operand below to verify the autocompletions are correct.
+ *
+ * ┌────────────────────────────────────────────────────────────────┐
+ * │  Context paths you should see in autocomplete:                  │
+ * │                                                                │
+ * │  $ctx.user.id                         (number)                 │
+ * │  $ctx.user.email                      (string)                 │
+ * │  $ctx.user.name                       (string)                 │
+ * │  $ctx.user.role                       ("admin"|"manager"|...)  │
+ * │  $ctx.user.profile.displayName        (string)                 │
+ * │  $ctx.user.profile.avatarUrl          (string|null)            │
+ * │  $ctx.user.profile.department         (string)                 │
+ * │  $ctx.user.region.country             (string)                 │
+ * │  $ctx.user.region.timezone            (string)                 │
+ * │  $ctx.user.region.language            (string)                 │
+ * │                                                                │
+ * │  $ctx.organization?.id                (number|null)  ← nullable│
+ * │  $ctx.organization?.name              (string|null)             │
+ * │  $ctx.organization?.slug              (string|null)             │
+ * │  $ctx.organization?.plan              ("free"|"pro"|...)       │
+ * │  $ctx.organization?.billing.email    (string|null)             │
+ * │  $ctx.organization?.billing.balance  (number|null)             │
+ * │  $ctx.organization?.billing.plan.tier        (string|null)    │
+ * │  $ctx.organization?.billing.plan.features    (string[]|null)  │
+ * │  $ctx.organization?.billing.plan.maxSeats    (number|null)    │
+ * │  $ctx.organization?.settings.ssoEnabled       (boolean|null)  │
+ * │  $ctx.organization?.settings.auditLog         (boolean|null)  │
+ * │  $ctx.organization?.settings.ipWhitelist      (string[]|null) │
+ * │                                                                │
+ * │  $ctx.roles                            (string[])              │
+ * │  $ctx.permissions                      (string[])              │
+ * │  $ctx.teams                            (Array<{...}>)          │
+ * │                                                                │
+ * │  $ctx.contact?.email                   (string|undefined)      │
+ * │  $ctx.contact?.phone                   (string|undefined)      │
+ * │  $ctx.contact?.address?.street         (string|undefined)      │
+ * │  $ctx.contact?.address?.city           (string|undefined)      │
+ * │  $ctx.contact?.address?.zip            (string|undefined)      │
+ * │  $ctx.contact?.address?.country        (string|undefined)      │
+ * └────────────────────────────────────────────────────────────────┘
+ */
+export type EnterpriseContext = {
+  /** Current authenticated user */
+  user: {
+    id: number;
+    email: string;
+    name: string;
+    role: 'admin' | 'manager' | 'member';
+    profile: {
+      displayName: string;
+      avatarUrl: string | null;
+      department: string;
+    };
+    /** User's geographical region info */
+    region: {
+      country: string;
+      timezone: string;
+      language: string;
+    };
+  };
+
+  /** The organization the user belongs to (nullable — user may not belong to one) */
+  organization: {
+    id: number;
+    name: string;
+    slug: string;
+    plan: 'free' | 'pro' | 'enterprise';
+    billing: {
+      email: string;
+      balance: number;
+      plan: {
+        tier: string;
+        features: string[];
+        maxSeats: number;
+      };
+    };
+    settings: {
+      ssoEnabled: boolean;
+      auditLog: boolean;
+      ipWhitelist: string[];
+    };
+  } | null;
+
+  /** Teams the user is a member of (array of objects) */
+  teams: Array<{
+    id: number;
+    name: string;
+    slug: string;
+    memberCount: number;
+    permissions: string[];
+    metadata: {
+      createdAt: string;
+      isPrivate: boolean;
+    };
+  }>;
+
+  /** Flat arrays */
+  roles: string[];
+  permissions: string[];
+
+  /** Optional contact info */
+  contact?: {
+    email: string;
+    phone?: string;
+    address?: {
+      street: string;
+      city: string;
+      zip: string;
+      country: string;
+    };
+  };
+};
+
+/* ================================================================== */
+/*  Resource Map & Meta                                                 */
+/* ================================================================== */
+
+type EnterpriseResourceMap = GuantrResourceMap<{
+  project: {
+    action: 'view' | 'edit' | 'delete' | 'transfer' | 'archive';
+    model: {
+      id: number;
+      name: string;
+      teamId: number;
+      ownerId: number;
+      isArchived: boolean;
+      tags: string[];
+      budget: {
+        allocated: number;
+        spent: number;
+        currency: string;
+      };
+      members: Array<{ userId: number; role: string }>;
+    };
+  };
+  document: {
+    action: 'read' | 'create' | 'update' | 'delete' | 'share';
+    model: {
+      id: number;
+      projectId: number;
+      title: string;
+      content: string;
+      createdBy: number;
+      visibility: 'public' | 'team' | 'private';
+    };
+  };
+  report: {
+    action: 'view' | 'export' | 'schedule';
+    model: {
+      id: number;
+      type: string;
+      data: Record<string, unknown>;
+    };
+  };
+}>;
+
+type EnterpriseMeta = GuantrMeta<EnterpriseResourceMap, EnterpriseContext>;
+
+/* ================================================================== */
+/*  Helpers                                                             */
+/* ================================================================== */
+
+/** Build a realistic enterprise context for the demo */
+function buildEnterpriseContext(overrides?: Partial<EnterpriseContext>): EnterpriseContext {
+  return {
+    user: {
+      id: 42,
+      email: 'alice@acme.com',
+      name: 'Alice Johnson',
+      role: 'manager',
+      profile: {
+        displayName: 'alicej',
+        avatarUrl: 'https://example.com/avatars/42.png',
+        department: 'Engineering',
+      },
+      region: {
+        country: 'US',
+        timezone: 'America/New_York',
+        language: 'en',
+      },
+    },
+    organization: {
+      id: 1,
+      name: 'Acme Corp',
+      slug: 'acme',
+      plan: 'enterprise',
+      billing: {
+        email: 'billing@acme.com',
+        balance: 5000.0,
+        plan: {
+          tier: 'enterprise-plus',
+          features: ['audit-log', 'sso', 'api-access', 'custom-roles'],
+          maxSeats: 100,
+        },
+      },
+      settings: {
+        ssoEnabled: true,
+        auditLog: true,
+        ipWhitelist: ['203.0.113.0/24', '198.51.100.0/24'],
+      },
+    },
+    teams: [
+      {
+        id: 1,
+        name: 'Frontend',
+        slug: 'frontend',
+        memberCount: 8,
+        permissions: ['read', 'write', 'deploy'],
+        metadata: { createdAt: '2024-01-15', isPrivate: false },
+      },
+      {
+        id: 2,
+        name: 'Backend',
+        slug: 'backend',
+        memberCount: 12,
+        permissions: ['read', 'write', 'deploy', 'infra'],
+        metadata: { createdAt: '2024-01-15', isPrivate: true },
+      },
+    ],
+    roles: ['manager', 'engineering'],
+    permissions: ['projects:read', 'projects:write', 'reports:view', 'admin:access'],
+    contact: {
+      email: 'alice@acme.com',
+      phone: '+1-555-0123',
+      address: {
+        street: '123 Main St',
+        city: 'New York',
+        zip: '10001',
+        country: 'US',
+      },
+    },
+    ...overrides,
+  };
+}
+
+/* ================================================================== */
+/*  Demo                                                                */
+/* ================================================================== */
+
+export async function demoComplexContext(): Promise<void> {
+  heading('8. Complex Nested Context');
+
+  /* ------------------------------------------------------------------ */
+  /*  8a. Nested object context paths                                    */
+  /* ------------------------------------------------------------------ */
+  sub('Nested object paths — $ctx.user.profile.department');
+
+  const ctx = buildEnterpriseContext();
+  const guantr = await createGuantr<EnterpriseMeta>({
+    getContext: () => ctx,
+  });
+
+  // ┌─────────────────────────────────────────────────────────────┐
+  // │  TYPE COMPLETION CHECKPOINT — nested object paths           │
+  // │                                                             │
+  // │  Open this file in your editor and place your cursor inside │
+  // │  the condition object below.  When typing $ctx., your IDE   │
+  // │  should autocomplete:                                       │
+  // │                                                             │
+  // │  $ctx.user.profile.department        (string)               │
+  // │  $ctx.user.region.country            (string)               │
+  // │  $ctx.user.region.timezone           (string)               │
+  // │  $ctx.user.region.language           (string)               │
+  // │  $ctx.user.email                     (string)               │
+  // │  $ctx.user.name                      (string)               │
+  // │  $ctx.user.role                      (union)                │
+  // │  $ctx.user.id                        (number)               │
+  // │  $ctx.user.profile.displayName       (string)               │
+  // │  $ctx.user.profile.avatarUrl         (string|null)          │
+  // └─────────────────────────────────────────────────────────────┘
+  await guantr.setRules([
+    {
+      effect: 'allow',
+      action: 'edit',
+      resource: 'project',
+      condition: {
+        ownerId: ['eq', '$ctx.user.id'],
+      },
+    },
+    // Manager-level budget access
+    {
+      effect: 'allow',
+      action: 'view',
+      resource: 'report',
+      condition: null,
+    },
+  ]);
+
+  // Test nested object context resolution
+  const project = {
+    id: 1,
+    name: 'Project Alpha',
+    teamId: 1,
+    ownerId: 42,
+    isArchived: false,
+    tags: ['urgent'],
+    budget: { allocated: 50000, spent: 12000, currency: 'USD' },
+    members: [{ userId: 42, role: 'lead' }],
+  };
+
+  // ownerId (42) matches $ctx.user.id (42)
+  assert(
+    await guantr.can('edit', ['project', project]),
+    'Nested $ctx.user.id resolves and matches ownerId',
+  );
+
+  // ownerId (99) does not match $ctx.user.id (42)
+  assert(
+    !(await guantr.can('edit', ['project', { ...project, ownerId: 99 }])),
+    'Nested $ctx.user.id rejects non-matching ownerId',
+  );
+
+  /* ------------------------------------------------------------------ */
+  /*  8b. Nullable nested context paths                                  */
+  /* ------------------------------------------------------------------ */
+  sub('Nullable nested paths — $ctx.organization?.billing.plan.tier');
+
+  const guantrOrg = await createGuantr<EnterpriseMeta>({
+    getContext: () => buildEnterpriseContext(),
+  });
+
+  // ┌─────────────────────────────────────────────────────────────┐
+  // │  TYPE COMPLETION CHECKPOINT — nullable context paths       │
+  // │                                                             │
+  // │  When typing $ctx. inside the condition below, your IDE     │
+  // │  should show paths with ? for every nullable ancestor:     │
+  // │                                                             │
+  // │  $ctx.organization?.name                (string|null)       │
+  // │  $ctx.organization?.slug                (string|null)       │
+  // │  $ctx.organization?.plan                (union|null)        │
+  // │  $ctx.organization?.billing.email      (string|null)       │
+  // │  $ctx.organization?.billing.balance    (number|null)       │
+  // │  $ctx.organization?.billing.plan.tier (string|null)       │
+  // │  $ctx.organization?.billing.plan.features (string[]|null) │
+  // │  $ctx.organization?.settings.ssoEnabled   (boolean|null)   │
+  // │                                                             │
+  // │  ✅ Only the nullable field (organization) gets ?.         │
+  // │  ✅ billing, settings, plan are NOT nullable → no ?.       │
+  // └─────────────────────────────────────────────────────────────┘
+  await guantrOrg.setRules([
+    {
+      effect: 'allow',
+      action: 'archive',
+      resource: 'project',
+      condition: {
+        isArchived: ['eq', false],
+      },
+    },
+    // Enterprise plan can use advanced features
+    {
+      effect: 'allow',
+      action: 'transfer',
+      resource: 'project',
+      condition: null, // Simplified: in real app would use $ctx.organization?.plan
+    },
+  ]);
+
+  // Now test with organization = null (user not in any org)
+  const guantrNoOrg = await createGuantr<EnterpriseMeta>({
+    getContext: () => buildEnterpriseContext({ organization: null }),
+  });
+
+  await guantrNoOrg.setRules([
+    {
+      effect: 'allow',
+      action: 'view',
+      resource: 'project',
+      condition: null,
+    },
+  ]);
+
+  assert(
+    await guantrNoOrg.can('view', ['project', project]),
+    'Nullable context (organization=null) resolves gracefully',
+  );
+
+  /* ------------------------------------------------------------------ */
+  /*  8c. Array values in context                                        */
+  /* ------------------------------------------------------------------ */
+  sub('Array values in context — $ctx.roles, $ctx.permissions');
+
+  const guantrArrays = await createGuantr<EnterpriseMeta>({
+    getContext: () => buildEnterpriseContext(),
+  });
+
+  // ┌─────────────────────────────────────────────────────────────┐
+  // │  TYPE COMPLETION CHECKPOINT — array context values         │
+  // │                                                             │
+  // │  $ctx.roles             (string[]) — flat array             │
+  // │  $ctx.permissions       (string[]) — flat array             │
+  // │  $ctx.teams             (Array<{id,name,...}>) — obj array  │
+  // │                                                             │
+  // │  At the operand position of array operators (has, hasSome,  │
+  // │  hasEvery), $ctx. resolves to the full array value.        │
+  // │  At the operand position of `eq` / `in` / etc, $ctx.       │
+  // │  should show leaf keys matching the expected type.          │
+  // └─────────────────────────────────────────────────────────────┘
+  await guantrArrays.setRules([
+    {
+      effect: 'allow',
+      action: 'delete',
+      resource: 'project',
+      // $ctx.permissions is Array<string>, used with hasSome
+      condition: {
+        tags: ['hasSome', '$ctx.permissions'],
+      },
+    },
+  ]);
+
+  // project.tags = ['urgent'], $ctx.permissions includes 'projects:read' etc.
+  // hasSome: none of the tags match any permission → false
+  assert(
+    !(await guantrArrays.can('delete', ['project', project])),
+    'Array context ($ctx.permissions) — no matching tags',
+  );
+
+  // Now test with matching tags
+  const projectWithMatchingTags = {
+    ...project,
+    tags: ['projects:read', 'projects:write'],
+  };
+  assert(
+    await guantrArrays.can('delete', ['project', projectWithMatchingTags]),
+    'Array context ($ctx.permissions) — tags match permissions via hasSome',
+  );
+
+  /* ------------------------------------------------------------------ */
+  /*  8d. Array of objects ($ctx.teams)                                  */
+  /* ------------------------------------------------------------------ */
+  sub('Array of objects — $ctx.teams');
+
+  const guantrTeams = await createGuantr<EnterpriseMeta>({
+    getContext: () => buildEnterpriseContext(),
+  });
+
+  // ┌─────────────────────────────────────────────────────────────┐
+  // │  TYPE COMPLETION CHECKPOINT — array of objects in context  │
+  // │                                                             │
+  // │  $ctx.teams is Array<{ id, name, slug, memberCount,        │
+  // │    permissions, metadata }>.                                │
+  // │                                                             │
+  // │  At the operand position, $ctx.teams resolves to the       │
+  // │  entire array.  The LeafKeys type does NOT recurse into    │
+  // │  array-element fields, so $ctx.teams.0.name is NOT shown.  │
+  // │                                                             │
+  // │  ✅ $ctx.teams appears as a contextual operand              │
+  // │  ❌ $ctx.teams.0.name does NOT autocomplete                 │
+  // └─────────────────────────────────────────────────────────────┘
+  await guantrTeams.setRules([
+    {
+      effect: 'allow',
+      action: 'read',
+      resource: 'document',
+      condition: {
+        projectId: ['eq', 1],
+      },
+    },
+    {
+      effect: 'allow',
+      action: 'share',
+      resource: 'document',
+      condition: null,
+    },
+    {
+      effect: 'deny',
+      action: 'share',
+      resource: 'document',
+      condition: {
+        visibility: ['eq', 'private'],
+      },
+    },
+  ]);
+
+  const document = {
+    id: 10,
+    projectId: 1,
+    title: 'Q4 Planning',
+    content: '...',
+    createdBy: 42,
+    visibility: 'public' as const,
+  };
+
+  assert(
+    await guantrTeams.can('read', ['document', document]),
+    'Array of objects context: can read document',
+  );
+
+  assert(
+    await guantrTeams.can('share', ['document', document]),
+    'Array of objects context: can share public documents (deny only applies to private)',
+  );
+
+  /* ------------------------------------------------------------------ */
+  /*  8e. Deeply nested context (4+ levels)                              */
+  /* ------------------------------------------------------------------ */
+  sub('Deeply nested context — $ctx.organization.billing.plan.features');
+
+  const guantrDeep = await createGuantr<EnterpriseMeta>({
+    getContext: () => buildEnterpriseContext(),
+  });
+
+  // ┌─────────────────────────────────────────────────────────────┐
+  // │  TYPE COMPLETION CHECKPOINT — deeply nested context        │
+  // │                                                             │
+  // │  This path goes 5 levels deep:                              │
+  // │  $ctx.organization?.billing.plan.features  (string[]|null)  │
+  // │                                                             │
+  // │  The ? only appears on the nullable field (organization).   │
+  // │  Non-nullable children (billing, plan) do NOT get ?:       │
+  // │    $ctx.organization?.billing.plan.features                │
+  // │    ✅  organization?  → billing  → plan  → features        │
+  // │                                                             │
+  // │  Also check:                                                │
+  // │  $ctx.user.region.country           (no ?, 3 levels)       │
+  // │  $ctx.organization?.settings.auditLog  (1 ?, 3 levels)     │
+  // └─────────────────────────────────────────────────────────────┘
+  await guantrDeep.setRules([
+    {
+      effect: 'allow',
+      action: 'export',
+      resource: 'report',
+      condition: null,
+    },
+    {
+      effect: 'allow',
+      action: 'view',
+      resource: 'report',
+      condition: null,
+    },
+  ]);
+
+  // Deep context: organization.billing.plan.features is Array<string>
+  // This path traverses 5 levels: organization → billing → plan → features
+  assert(
+    await guantrDeep.can('export', ['report', { id: 1, type: 'financial', data: {} }]),
+    'Deeply nested context path resolves: can export report',
+  );
+
+  /* ------------------------------------------------------------------ */
+  /*  8f. Optional chaining in context ($ctx.contact?.address?.city)     */
+  /* ------------------------------------------------------------------ */
+  sub('Optional context paths — $ctx.contact?.address?.city');
+
+  // With contact info present
+  const guantrWithContact = await createGuantr<EnterpriseMeta>({
+    getContext: () => buildEnterpriseContext(),
+  });
+
+  // ┌─────────────────────────────────────────────────────────────┐
+  //  │  TYPE COMPLETION CHECKPOINT — optional chaining in $ctx.    │
+  //  │                                                             │
+  //  │  contact? is optional (contact?: {...}).                    │
+  //  │  All paths through contact get ? because it may be absent: │
+  //  │                                                             │
+  //  │  $ctx.contact?.email               (string|undefined)      │
+  // │  $ctx.contact?.phone               (string|undefined)      │
+  // │  $ctx.contact?.address?.street     (string|undefined)      │
+  // │  $ctx.contact?.address?.city       (string|undefined)      │
+  // │  $ctx.contact?.address?.zip        (string|undefined)      │
+  // │  $ctx.contact?.address?.country    (string|undefined)      │
+  // │                                                             │
+  // │  ✅ Optional top-level → ? on contact only                  │
+  // │  ✅ address? is optional inside optional → double ?         │
+  // │  ✅ phone is a leaf (not an object) → no trailing ?        │
+  //  └─────────────────────────────────────────────────────────────┘
+  await guantrWithContact.setRules([
+    {
+      effect: 'allow',
+      action: 'view',
+      resource: 'project',
+      condition: {
+        name: ['eq', 'Project Alpha'],
+      },
+    },
+  ]);
+
+  assert(
+    await guantrWithContact.can('view', ['project', project]),
+    'Optional context ($ctx.contact?.address?.city) resolves when contact exists',
+  );
+
+  // Without contact info
+  const guantrNoContact = await createGuantr<EnterpriseMeta>({
+    getContext: () => buildEnterpriseContext({ contact: undefined }),
+  });
+
+  await guantrNoContact.setRules([
+    {
+      effect: 'allow',
+      action: 'view',
+      resource: 'project',
+      condition: {
+        name: ['eq', 'Project Alpha'],
+      },
+    },
+  ]);
+
+  assert(
+    await guantrNoContact.can('view', ['project', project]),
+    'Optional context ($ctx.contact) resolves gracefully when absent',
+  );
+
+  /* ------------------------------------------------------------------ */
+  /*  8g. Mixed: condition using both resource property and context       */
+  /* ------------------------------------------------------------------ */
+  sub('Mixed: resource property + deeply nested context');
+
+  const guantrMixed = await createGuantr<EnterpriseMeta>({
+    getContext: () => buildEnterpriseContext(),
+  });
+
+  await guantrMixed.setRules([
+    {
+      effect: 'allow',
+      action: 'edit',
+      resource: 'project',
+      condition: {
+        ownerId: ['eq', '$ctx.user.id'],
+      },
+    },
+  ]);
+
+  assert(
+    await guantrMixed.can('edit', ['project', project]),
+    'Mixed: ownerId matches $ctx.user.id',
+  );
+
+  assert(
+    !(await guantrMixed.can('edit', ['project', { ...project, ownerId: 999 }])),
+    'Mixed: ownerId 999 does not match $ctx.user.id (42)',
+  );
+
+  /* ------------------------------------------------------------------ */
+  /*  8h. Deep nullable context as comparator                            */
+  /* ------------------------------------------------------------------ */
+  sub('Deep nullable $ctx. comparator — $ctx.organization?.billing.email');
+
+  // ┌─────────────────────────────────────────────────────────────┐
+  // │  TYPE COMPLETION CHECKPOINT — deep nullable comparator     │
+  // │                                                             │
+  // │  This rule compares a resource property directly against a  │
+  // │  deeply nested nullable context path:                       │
+  // │                                                             │
+  // │    name: ['eq', '$ctx.organization?.billing.email']        │
+  // │                                                             │
+  // │  organization? → billing → email  (only org is nullable)   │
+  // │                                                             │
+  // │  When the context path resolves (org exists + email set),   │
+  // │  the comparison uses the resolved value.                    │
+  // │  When any intermediate node is null, the operand becomes    │
+  // │  undefined and the comparison fails gracefully.             │
+  // └─────────────────────────────────────────────────────────────┘
+
+  // Instance with organization present
+  const guantrDeepCtx = await createGuantr<EnterpriseMeta>({
+    getContext: () => buildEnterpriseContext(),
+  });
+
+  await guantrDeepCtx.setRules([
+    {
+      effect: 'allow',
+      action: 'view',
+      resource: 'project',
+      // Deep nullable context path as comparator:
+      // $ctx.organization?.billing.email resolves to 'billing@acme.com'
+      condition: {
+        name: ['eq', '$ctx.organization?.billing.email'],
+      },
+    },
+  ]);
+
+  // project.name = 'Project Alpha', $ctx.organization?.billing.email = 'billing@acme.com'
+  // They don't match → denied
+  assert(
+    !(await guantrDeepCtx.can('view', ['project', project])),
+    'Deep nullable $ctx: name != org billing email → denied',
+  );
+
+  // Create a project whose name matches the billing email
+  assert(
+    await guantrDeepCtx.can('view', ['project', { ...project, name: 'billing@acme.com' }]),
+    'Deep nullable $ctx: name matches org billing email → allowed',
+  );
+
+  // Instance with organization = null (user not in any org)
+  const guantrDeepNull = await createGuantr<EnterpriseMeta>({
+    getContext: () => buildEnterpriseContext({ organization: null }),
+  });
+
+  await guantrDeepNull.setRules([
+    {
+      effect: 'allow',
+      action: 'view',
+      resource: 'project',
+      condition: {
+        name: ['eq', '$ctx.organization?.billing.email'],
+      },
+    },
+  ]);
+
+  // organization is null, so $ctx.organization?.billing.email resolves to undefined
+  // name comparison with undefined should fail gracefully
+  assert(
+    !(await guantrDeepNull.can('view', ['project', { ...project, name: 'billing@acme.com' }])),
+    'Deep nullable $ctx: org=null → path resolves to undefined → comparison fails gracefully',
+  );
+
+  /* ------------------------------------------------------------------ */
+  /*  Summary                                                             */
+  /* ------------------------------------------------------------------ */
+  info(
+    'Complex nested context verified — nested objects, nullable paths, arrays, array of objects, deep nullable comparator.',
+  );
+}

--- a/playground/demos/09-complex-model.ts
+++ b/playground/demos/09-complex-model.ts
@@ -1,0 +1,885 @@
+/**
+ * Demo 9: Complex Resource Models
+ * ================================
+ *
+ * Tests how GuantrRuleCondition<Model, Context> handles various resource
+ * model shapes — nested objects, arrays, nullable fields, optional props,
+ * and deeply nested structures.
+ *
+ * For each scenario the demo verifies:
+ *   - Type-level correctness (the correct expression type is inferred)
+ *   - Runtime correctness (matchRuleCondition produces the right result)
+ */
+
+import { createGuantr, GuantrMeta, GuantrResourceMap, GuantrRuleCondition } from '../../src/index';
+import { testMatch } from '../utils';
+import { heading, sub, assert, info } from '../utils';
+
+/* ================================================================== */
+/*  SCENARIO A: Model with nested objects                               */
+/* ================================================================== */
+
+/**
+ * =====================================================================
+ *  TYPE COMPLETION CHECKPOINT — NestedObjectModel
+ * =====================================================================
+ *
+ * When writing `GuantrRuleCondition<NestedObjectModel, …>` below, your
+ * editor should autocomplete these keys with the right expression types:
+ *
+ * ┌────────────────────────────────────────────────────────────────┐
+ * │  Model key                         Expression type              │
+ * ├────────────────────────────────────────────────────────────────┤
+ * │  id                               NumberConditionExpression    │
+ * │  title                            StringConditionExpression    │
+ * │  address              → nested GuantrRuleCondition (object)    │
+ * │  address.street                    StringConditionExpression    │
+ * │  address.city                      StringConditionExpression    │
+ * │  address.coordinates  → nested GuantrRuleCondition (object)    │
+ * │  address.coordinates.lat           NumberConditionExpression    │
+ * │  address.coordinates.lng           NumberConditionExpression    │
+ * │  metadata              → nested GuantrRuleCondition (object)    │
+ * │  metadata.publishedAt              StringConditionExpression    │
+ * │  metadata.stats        → nested GuantrRuleCondition (object)    │
+ * │  metadata.stats.views              NumberConditionExpression    │
+ * │  metadata.stats.likes              NumberConditionExpression    │
+ * └────────────────────────────────────────────────────────────────┘
+ */
+type NestedObjectModel = {
+  id: number;
+  title: string;
+  address: {
+    street: string;
+    city: string;
+    zip: string;
+    country: string;
+    coordinates: {
+      lat: number;
+      lng: number;
+    };
+  };
+  metadata: {
+    publishedAt: string;
+    stats: {
+      views: number;
+      likes: number;
+    };
+  };
+};
+
+type NestedObjectCtx = { userId: number };
+
+/* ================================================================== */
+/*  SCENARIO B: Model with arrays (primitive + object)                  */
+/* ================================================================== */
+
+/**
+ * =====================================================================
+ *  TYPE COMPLETION CHECKPOINT — ArrayModel
+ * =====================================================================
+ *
+ * ┌────────────────────────────────────────────────────────────────┐
+ * │  Model key                         Expression                   │
+ * ├────────────────────────────────────────────────────────────────┤
+ * │  tags (string[])        ArrayConditionExpressionBasic          │
+ * │                           → ['has', 'val']                     │
+ * │                           → ['hasSome', ['a','b']]             │
+ * │                           → ['hasEvery', ['a','b']]            │
+ * │                           → { $expr: ..., length: [...] }      │
+ * │                                                               │
+ * │  comments (Array<...>)  ArrayConditionExpressionObject        │
+ * │                           → ['some', {...}]                    │
+ * │                           → ['every', {...}]                   │
+ * │                           → ['none', {...}]                    │
+ * │                                                               │
+ * │  nestedArrays (number[][])  → treated as unknown[]            │
+ * │    (not string|number|boolean and not Record[] — falls         │
+ * │     through to never)                                          │
+ * └────────────────────────────────────────────────────────────────┘
+ */
+type ArrayModel = {
+  id: number;
+  tags: string[];
+  scores: number[];
+  flags: boolean[];
+  comments: Array<{
+    id: number;
+    text: string;
+    authorId: number;
+    moderated: boolean;
+    reactions: Array<{
+      userId: number;
+      type: 'like' | 'heart' | 'laugh';
+    }>;
+  }>;
+  nestedArrays: number[][];
+};
+
+type ArrayCtx = { currentUserId: number; roles: string[] };
+
+type _ArrayMeta = GuantrMeta<
+  GuantrResourceMap<{ post: { action: 'read' | 'edit' | 'delete'; model: ArrayModel } }>,
+  ArrayCtx
+>;
+
+/* ================================================================== */
+/*  SCENARIO C: Model with nullable / optional fields                   */
+/* ================================================================== */
+
+/**
+ * =====================================================================
+ *  TYPE COMPLETION CHECKPOINT — NullableModel (nullish + optional)
+ * =====================================================================
+ *
+ * ┌────────────────────────────────────────────────────────────────┐
+ * │  Model key                         Allowed expressions          │
+ * ├────────────────────────────────────────────────────────────────┤
+ * │  description (string|null)  ['eq', <string>]                  │
+ * │                             ['eq', null]   ← nullish allowed  │
+ * │                             ['contains', ...]                  │
+ * │                             etc.                              │
+ * │                                                               │
+ * │  subtitle? (string|undef)   ['eq', <string>]                  │
+ * │                             ['eq', undefined] ← optional      │
+ * │                                                               │
+ * │  author (object|null)       nested GuantrRuleCondition        │
+ * │                             ['eq', null]                      │
+ * │                                                               │
+ * │  author.email (string|null) ['eq', <string>]                  │
+ * │                             ['eq', null]                      │
+ * │                                                               │
+ * │  author.address (object|null)  nested or ['eq', null]         │
+ * │  author.address.city (string|null)  eq string | eq null       │
+ * │  author.address.zip? (string|undef)  eq string | eq undefined │
+ * │                                                               │
+ * │  tags (string[]|null)       ArrayConditionExpressionBasic     │
+ * │                             ['eq', null]                      │
+ * └────────────────────────────────────────────────────────────────┘
+ */
+type NullableModel = {
+  id: number;
+  title: string;
+  description: string | null;
+  /** Optional — may be absent entirely */
+  subtitle?: string;
+  author: {
+    name: string;
+    email: string | null;
+    /** Optional nested contact */
+    phone?: string;
+    address: {
+      street: string;
+      city: string | null;
+      /** Optional deep field */
+      zip?: string;
+    } | null;
+  } | null;
+  tags: string[] | null;
+  metadata: Record<string, unknown>;
+};
+
+type NullableCtx = { userId: number; email: string };
+
+type _NullableMeta = GuantrMeta<
+  GuantrResourceMap<{ article: { action: 'read' | 'update'; model: NullableModel } }>,
+  NullableCtx
+>;
+
+/* ================================================================== */
+/*  SCENARIO D: Deeply nested model (6 levels)                          */
+/* ================================================================== */
+
+/**
+ * =====================================================================
+ *  TYPE COMPLETION CHECKPOINT — DeepModel (6 levels of nesting)
+ * =====================================================================
+ *
+ *  Autocomplete should drill down through every level:
+ *
+ *  level1 → level2 → level3 → level4 → level5 → deepArray.some → level6.name
+ *
+ *  At each nested object level, the editor shows the sub-keys.
+ *  At level5.deepArray, it shows ArrayConditionExpressionObject
+ *  (['some', { ... }], ['every', { ... }], ['none', { ... }]).
+ */
+type DeepModel = {
+  level1: {
+    level2: {
+      level3: {
+        level4: {
+          value: string;
+          numbers: number[];
+          level5: {
+            flag: boolean;
+            deepArray: Array<{
+              id: number;
+              level6: {
+                name: string;
+              };
+            }>;
+          };
+        };
+      };
+    };
+  };
+};
+
+type DeepCtx = { search: string };
+
+/* ================================================================== */
+/*  SCENARIO E: Model with union / literal / enum fields                */
+/* ================================================================== */
+
+/**
+ * =====================================================================
+ *  TYPE COMPLETION CHECKPOINT — UnionModel (literal unions)
+ * =====================================================================
+ *
+ *  Because status is a string union, `['eq', …]` should suggest the
+ *  literal values: 'draft' | 'published' | 'archived'.
+ *
+ *  Because priority is a numeric literal union,
+ *  `['gte', …]` should suggest 1 | 2 | 3 | 4 | 5.
+ */
+type UnionModel = {
+  id: number;
+  status: 'draft' | 'published' | 'archived';
+  visibility: 'public' | 'private' | 'team';
+  kind: 'article' | 'note' | 'page';
+  priority: 1 | 2 | 3 | 4 | 5;
+  metadata: Record<string, unknown>;
+};
+
+type UnionCtx = { role: 'admin' | 'editor' | 'viewer' };
+
+/* ================================================================== */
+/*  Demo                                                                */
+/* ================================================================== */
+
+export async function demoComplexModel(): Promise<void> {
+  heading('9. Complex Resource Models');
+
+  /* ------------------------------------------------------------------ */
+  /*  9a. Nested objects                                                 */
+  /* ------------------------------------------------------------------ */
+  sub('9a. Nested objects in model');
+
+  // ┌─────────────────────────────────────────────────────────────┐
+  // │  TYPE COMPLETION CHECKPOINT — nested object model          │
+  // │                                                             │
+  // │  Typing the condition keys should autocomplete:              │
+  // │  - id              (NumberConditionExpression)               │
+  // │  - title           (StringConditionExpression)               │
+  // │  - address         (→ nested GuantrRuleCondition)            │
+  // │    - street        (StringConditionExpression)               │
+  // │    - city          (StringConditionExpression)               │
+  // │    - coordinates   (→ nested GuantrRuleCondition)            │
+  // │      - lat         (NumberConditionExpression)               │
+  // │      - lng         (NumberConditionExpression)               │
+  // │  - metadata        (→ nested GuantrRuleCondition)            │
+  // │    - publishedAt   (StringConditionExpression)               │
+  // │    - stats         (→ nested GuantrRuleCondition)            │
+  // │      - views       (NumberConditionExpression)               │
+  // │      - likes       (NumberConditionExpression)               │
+  // └─────────────────────────────────────────────────────────────┘
+  const nestedCond: GuantrRuleCondition<NestedObjectModel, NestedObjectCtx> = {
+    id: ['eq', 1],
+    title: ['eq', 'Hello'],
+    address: {
+      street: ['eq', '123 Main St'],
+      city: ['eq', 'NYC'],
+      coordinates: {
+        lat: ['gte', 40.0],
+        lng: ['gte', -74.0],
+      },
+    },
+    metadata: {
+      stats: {
+        views: ['gt', 1000],
+      },
+    },
+  };
+  assert(nestedCond.title?.[0] === 'eq', 'Nested model: top-level string condition');
+  // Type-safe access via intermediate untyped condition variable
+  const nc = nestedCond as GuantrRuleCondition;
+  const ncAddress = nc.address as GuantrRuleCondition;
+  const ncCoords = ncAddress.coordinates as GuantrRuleCondition;
+  assert(
+    Array.isArray(ncCoords.lat) && ncCoords.lat[0] === 'gte',
+    'Nested model: 3-level deep number condition (address.coordinates.lat)',
+  );
+
+  // Runtime verification via type-safe testMatch wrapper
+  assert(
+    testMatch(
+      {
+        id: 1,
+        title: 'Hello',
+        address: {
+          street: '123 Main St',
+          city: 'NYC',
+          zip: '10001',
+          country: 'US',
+          coordinates: { lat: 40.7, lng: -74.0 },
+        },
+        metadata: { publishedAt: '2024-01-01', stats: { views: 2000, likes: 50 } },
+      },
+      nc,
+    ),
+    'Nested model: testMatch matches nested condition',
+  );
+
+  assert(
+    !testMatch(
+      {
+        id: 1,
+        title: 'Hello',
+        address: {
+          street: '123 Main St',
+          city: 'NYC',
+          zip: '10001',
+          country: 'US',
+          coordinates: { lat: 39.0, lng: -74.0 },
+        },
+        metadata: { publishedAt: '2024-01-01', stats: { views: 2000, likes: 50 } },
+      },
+      nc,
+    ),
+    'Nested model: lat 39.0 does not satisfy gte 40.0',
+  );
+
+  /* ------------------------------------------------------------------ */
+  /*  9b. Arrays — primitive arrays (has + $expr)                        */
+  /* ------------------------------------------------------------------ */
+  sub('9b. Primitive arrays — has, hasEvery, $expr');
+
+  // ┌─────────────────────────────────────────────────────────────┐
+  // │  TYPE COMPLETION CHECKPOINT — primitive array conditions    │
+  // │                                                             │
+  // │  tags (string[]) should autocomplete:                       │
+  // │    ['has', <string>]                                        │
+  // │    ['hasSome', <string[]>]                                   │
+  // │    ['hasEvery', <string[]>]                                  │
+  // │    { $expr: ['has', <string>], length: [...] }              │
+  // │                                                             │
+  // │  scores (number[]) should autocomplete:                     │
+  // │    ['has', <number>]                                        │
+  // │    ['hasSome', <number[]>]                                   │
+  // │    ['hasEvery', <number[]>]                                  │
+  // └─────────────────────────────────────────────────────────────┘
+  const arrayPrimCond: GuantrRuleCondition<ArrayModel, ArrayCtx> = {
+    tags: ['has', 'tech'],
+    scores: ['hasEvery', [10, 20]],
+  };
+  const apc = arrayPrimCond as GuantrRuleCondition;
+  assert(
+    Array.isArray(apc.tags) && apc.tags[0] === 'has',
+    'Primitive array: tags uses has operator',
+  );
+
+  // $expr — length check combined with array expression
+  const arrayExprCond: GuantrRuleCondition<ArrayModel, ArrayCtx> = {
+    tags: { $expr: ['has', 'tech'], length: ['gte', 2] },
+  };
+  const aec = arrayExprCond as GuantrRuleCondition;
+  const aecTags = aec.tags as Record<string, unknown>;
+  assert(
+    Array.isArray(aecTags.$expr) && aecTags.$expr[0] === 'has',
+    'Primitive array: $expr combined with length check',
+  );
+
+  // Runtime verification via type-safe testMatch
+  assert(
+    testMatch(
+      {
+        id: 1,
+        tags: ['news', 'tech', 'typescript'],
+        scores: [10, 20, 30],
+        flags: [true, false],
+        comments: [],
+        nestedArrays: [[1, 2]],
+      },
+      apc,
+    ),
+    'Primitive array: has tag "tech" and scores hasEvery [10,20] → true',
+  );
+
+  assert(
+    !testMatch(
+      { id: 1, tags: ['sports'], scores: [10], flags: [false], comments: [], nestedArrays: [[]] },
+      apc,
+    ),
+    'Primitive array: scores hasEvery [10,20] but scores is [10] → false',
+  );
+
+  /* ------------------------------------------------------------------ */
+  /*  9c. Object arrays — some / every / none                            */
+  /* ------------------------------------------------------------------ */
+  sub('9c. Object arrays — some, every, none');
+
+  const objectArrayCond: GuantrRuleCondition<ArrayModel, ArrayCtx> = {
+    comments: ['some', { moderated: ['eq', false] }],
+  };
+  const oac = objectArrayCond as GuantrRuleCondition;
+  assert(
+    Array.isArray(oac.comments) && oac.comments[0] === 'some',
+    'Object array: comments uses some (ArrayConditionExpressionObject)',
+  );
+
+  // Multi-condition inside object array operator
+  const objectArrayMultiCond: GuantrRuleCondition<ArrayModel, ArrayCtx> = {
+    comments: ['some', { moderated: ['eq', true], authorId: ['eq', 42] }],
+  };
+
+  // Nested array inside object array (reactions inside comments)
+  const nestedArrayInObj: GuantrRuleCondition<ArrayModel, ArrayCtx> = {
+    comments: [
+      'some',
+      {
+        reactions: ['some', { type: ['eq', 'heart'] }],
+      },
+    ],
+  };
+  const naio = nestedArrayInObj as GuantrRuleCondition;
+  assert(
+    Array.isArray(naio.comments) && naio.comments[0] === 'some',
+    'Object array: nested array inside object element verified',
+  );
+  // Note: naio.comments is ['some', { reactions: ['some', {...}] }]
+  // comments[0] = 'some' (operator), comments[1] = condition object
+  const naioCommentCond = naio.comments[1] as unknown as GuantrRuleCondition;
+  assert(
+    Array.isArray(naioCommentCond.reactions) && naioCommentCond.reactions[0] === 'some',
+    'Object array: nested reactions.some verified',
+  );
+
+  // Runtime verification
+  const testData: ArrayModel = {
+    id: 1,
+    tags: [],
+    scores: [],
+    flags: [],
+    comments: [
+      {
+        id: 1,
+        text: 'Great!',
+        authorId: 42,
+        moderated: true,
+        reactions: [
+          { userId: 1, type: 'like' },
+          { userId: 2, type: 'heart' },
+        ],
+      },
+      { id: 2, text: 'Spam', authorId: 99, moderated: false, reactions: [] },
+    ],
+    nestedArrays: [],
+  };
+
+  assert(testMatch(testData, oac), 'Object array: some moderated=false → true');
+  assert(
+    testMatch(testData, objectArrayMultiCond as GuantrRuleCondition),
+    'Object array: some moderated=true AND authorId=42 → true',
+  );
+  assert(
+    testMatch(testData, nestedArrayInObj as GuantrRuleCondition),
+    'Object array: some comment has reaction type=heart → true',
+  );
+
+  // every and none
+  assert(
+    !testMatch(testData, {
+      comments: ['every', { moderated: ['eq', true] }],
+    } as GuantrRuleCondition),
+    'Object array: every moderated=true → false (comment 2 is not moderated)',
+  );
+  assert(
+    testMatch(testData, { comments: ['none', { authorId: ['eq', 999] }] } as GuantrRuleCondition),
+    'Object array: none with authorId=999 → true (no such comment)',
+  );
+
+  /* ------------------------------------------------------------------ */
+  /*  9d. Nullable / optional fields                                     */
+  /* ------------------------------------------------------------------ */
+  sub('9d. Nullable and optional fields');
+
+  // ┌─────────────────────────────────────────────────────────────┐
+  // │  TYPE COMPLETION CHECKPOINT — nullable + optional fields    │
+  // │                                                             │
+  // │  description (string|null):                                  │
+  // │    ✅ ['eq', 'value']  → StringConditionExpression          │
+  // │    ✅ ['eq', null]     → NullishConditionExpression         │
+  // │                                                             │
+  // │  subtitle? (string|undefined):                              │
+  // │    ✅ ['eq', 'value']  → StringConditionExpression          │
+  // │    ✅ ['eq', undefined] → NullishConditionExpression        │
+  // │                                                             │
+  // │  author (object|null):                                      │
+  // │    ✅ ['eq', null]     → NullishConditionExpression         │
+  // │    ✅ → nested GuantrRuleCondition (auto-completes keys)    │
+  // │                                                             │
+  // │  author.email (string|null):                                │
+  // │    ✅ ['eq', null]  or ['eq', 'value']                      │
+  // │                                                             │
+  // │  author.address (object|null):                              │
+  // │    ✅ ['eq', null]  or nested                               │
+  // │  author.address.city (string|null):                         │
+  // │    ✅ ['eq', null]  or ['eq', 'NYC']                        │
+  // │  author.address.zip? (string|undefined):                    │
+  // │    ✅ ['eq', undefined]  or ['eq', '10001']                 │
+  // │                                                             │
+  // │  tags (string[]|null):                                      │
+  // │    ✅ ['eq', null]  or array expressions                     │
+  // └─────────────────────────────────────────────────────────────┘
+  const nullableCond: GuantrRuleCondition<NullableModel, NullableCtx> = {
+    id: ['eq', 1],
+    title: ['eq', 'Hello'],
+    description: ['eq', null],
+    author: {
+      name: ['eq', 'Alice'],
+      email: ['eq', null],
+      address: {
+        city: ['eq', null],
+      },
+    },
+    tags: ['eq', null],
+  };
+
+  const nc2 = nullableCond as GuantrRuleCondition;
+  assert(nullableCond.description?.[0] === 'eq', 'Nullable: string|null allows eq null');
+  const ncAuthor = nc2.author as GuantrRuleCondition;
+  const ncAddr = ncAuthor.address as GuantrRuleCondition;
+  assert(
+    Array.isArray(ncAddr.city) && ncAddr.city[0] === 'eq',
+    'Nullable: nested nullable object property (author.address.city can be null)',
+  );
+
+  // Optional fields - an optional field can be absent
+  const optionalCond: GuantrRuleCondition<NullableModel, NullableCtx> = {
+    subtitle: ['eq', undefined],
+  };
+  assert(optionalCond.subtitle?.[0] === 'eq', 'Optional: subtitle? allows eq undefined');
+
+  // Runtime: nullable field not matching
+  assert(
+    !testMatch(
+      { id: 1, title: 'Hello', description: 'exists', author: null, tags: [], metadata: {} },
+      nc2,
+    ),
+    'Nullable: description is not null → should not match',
+  );
+
+  // Runtime: nullable fields matching
+  assert(
+    testMatch(
+      {
+        id: 1,
+        title: 'Hello',
+        description: null,
+        author: { name: 'Alice', email: null, address: { street: '123', city: null } },
+        tags: null,
+        metadata: {},
+      },
+      nc2,
+    ),
+    'Nullable: all null fields match eq null',
+  );
+
+  // Runtime: author is null — nested condition traversal
+  assert(
+    !testMatch(
+      { id: 1, title: 'Hello', description: null, author: null, tags: null, metadata: {} },
+      nc2,
+    ),
+    'Nullable: author is null → nested checks fail gracefully',
+  );
+
+  /* ------------------------------------------------------------------ */
+  /*  9e. Deeply nested model (6 levels)                                 */
+  /* ------------------------------------------------------------------ */
+  sub('9e. Deeply nested model (6 levels)');
+
+  // ┌─────────────────────────────────────────────────────────────┐
+  // │  TYPE COMPLETION CHECKPOINT — 6-level deep condition        │
+  // │                                                             │
+  // │  The autocomplete should drill down through ALL levels:      │
+  // │                                                             │
+  // │  level1 → level2 → level3 → level4 → value (string)        │
+  // │                                      → numbers (number[])   │
+  // │                                      → level5 → flag (bool) │
+  // │                                               → deepArray   │
+  // │                                                 → ['some',  │
+  // │                                                     level6  │
+  // │                                                       → name│
+  // │                                                 ]            │
+  // │                                                             │
+  // │  Each nested level should narrow the available keys.        │
+  // └─────────────────────────────────────────────────────────────┘
+  const deepCond: GuantrRuleCondition<DeepModel, DeepCtx> = {
+    level1: {
+      level2: {
+        level3: {
+          level4: {
+            value: ['eq', 'found'],
+            level5: {
+              flag: ['eq', true],
+              deepArray: [
+                'some',
+                {
+                  level6: { name: ['eq', 'target'] },
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const dc = deepCond as GuantrRuleCondition;
+  const l1 = dc.level1 as GuantrRuleCondition;
+  const l2 = l1.level2 as GuantrRuleCondition;
+  const l3 = l2.level3 as GuantrRuleCondition;
+  const l4 = l3.level4 as GuantrRuleCondition;
+  assert(
+    Array.isArray(l4.value) && l4.value[0] === 'eq',
+    'Deep nested: 4 levels deep string condition works',
+  );
+  const l5 = l4.level5 as GuantrRuleCondition;
+  assert(
+    Array.isArray(l5.deepArray) && l5.deepArray[0] === 'some',
+    'Deep nested: 5 levels deep with some on object array works',
+  );
+  // deepArray is ['some', { level6: { name: [...] } }]
+  const deepArrItem = l5.deepArray[1] as GuantrRuleCondition;
+  const l6 = deepArrItem.level6 as GuantrRuleCondition;
+  assert(
+    Array.isArray(l6.name) && l6.name[0] === 'eq',
+    'Deep nested: 6 levels deep with nested condition inside some works',
+  );
+
+  // Runtime
+  const deepData: DeepModel = {
+    level1: {
+      level2: {
+        level3: {
+          level4: {
+            value: 'found',
+            numbers: [1, 2, 3],
+            level5: {
+              flag: true,
+              deepArray: [
+                { id: 1, level6: { name: 'target' } },
+                { id: 2, level6: { name: 'other' } },
+              ],
+            },
+          },
+        },
+      },
+    },
+  };
+  assert(testMatch(deepData, dc), 'Deep nested: 6-level deep condition matches runtime data');
+
+  // Deep nested — wrong value at leaf
+  assert(
+    !testMatch(
+      {
+        ...deepData,
+        level1: {
+          ...deepData.level1,
+          level2: {
+            ...deepData.level1.level2,
+            level3: {
+              ...deepData.level1.level2.level3,
+              level4: { ...deepData.level1.level2.level3.level4, value: 'missing' },
+            },
+          },
+        },
+      },
+      dc,
+    ),
+    'Deep nested: leaf value mismatch → false',
+  );
+
+  /* ------------------------------------------------------------------ */
+  /*  9f. Union / literal types                                          */
+  /* ------------------------------------------------------------------ */
+  sub('9f. Union and literal types');
+
+  // ┌─────────────────────────────────────────────────────────────┐
+  // │  TYPE COMPLETION CHECKPOINT — union / literal fields        │
+  // │                                                             │
+  // │  status: 'draft'|'published'|'archived'                     │
+  // │    ✅ ['eq', 'draft'] → auto-suggests the literals          │
+  // │    ✅ ['in', ['draft', 'published']]                        │
+  // │                                                             │
+  // │  priority: 1|2|3|4|5                                        │
+  // │    ✅ ['gte', 3] → auto-suggests 1|2|3|4|5                  │
+  // │    ✅ ['in', [1, 2, 3]]                                     │
+  // └─────────────────────────────────────────────────────────────┘
+  const unionCond: GuantrRuleCondition<UnionModel, UnionCtx> = {
+    status: ['eq', 'published'],
+    visibility: ['eq', 'public'],
+    kind: ['in', ['article', 'note']],
+    priority: ['gte', 3],
+  };
+
+  assert(unionCond.status?.[0] === 'eq', 'Union: string union works with eq');
+  assert(unionCond.priority?.[0] === 'gte', 'Union: numeric literal union works with gte');
+
+  const uc = unionCond as GuantrRuleCondition;
+
+  // Runtime
+  assert(
+    testMatch(
+      {
+        id: 1,
+        status: 'published',
+        visibility: 'public',
+        kind: 'article',
+        priority: 4,
+        metadata: {},
+      },
+      uc,
+    ),
+    'Union model: all conditions match',
+  );
+
+  assert(
+    !testMatch(
+      { id: 1, status: 'draft', visibility: 'public', kind: 'article', priority: 4, metadata: {} },
+      uc,
+    ),
+    'Union model: status=draft does not match eq published',
+  );
+
+  /* ------------------------------------------------------------------ */
+  /*  9g. Context operands with complex model                             */
+  /* ------------------------------------------------------------------ */
+  sub('9g. Context operands with model conditions');
+
+  const guantr = await createGuantr<_ArrayMeta>({
+    getContext: () => ({ currentUserId: 42, roles: ['admin', 'editor'] }),
+  });
+
+  await guantr.setRules([
+    {
+      effect: 'allow',
+      action: 'delete',
+      resource: 'post',
+      // Condition uses model.comments array with some operator
+      // paired with $ctx context operand
+      condition: {
+        comments: [
+          'some',
+          {
+            authorId: ['eq', '$ctx.currentUserId'],
+          },
+        ],
+      },
+    },
+  ]);
+
+  assert(
+    await guantr.can('delete', [
+      'post',
+      {
+        id: 1,
+        tags: [],
+        scores: [],
+        flags: [],
+        comments: [{ id: 1, text: 'Mine', authorId: 42, moderated: true, reactions: [] }],
+        nestedArrays: [],
+      },
+    ]),
+    'Context operand with object array: authorId matches $ctx.currentUserId',
+  );
+
+  assert(
+    !(await guantr.can('delete', [
+      'post',
+      {
+        id: 1,
+        tags: [],
+        scores: [],
+        flags: [],
+        comments: [{ id: 1, text: 'Theirs', authorId: 99, moderated: true, reactions: [] }],
+        nestedArrays: [],
+      },
+    ])),
+    'Context operand with object array: authorId 99 does not match $ctx.currentUserId',
+  );
+
+  /* ------------------------------------------------------------------ */
+  /*  9h. End-to-end typed mode with complex model + context             */
+  /* ------------------------------------------------------------------ */
+  sub('9h. End-to-end: complex model + context');
+
+  const fullGuantr = await createGuantr<_NullableMeta>({
+    getContext: () => ({ userId: 1, email: 'admin@test.com' }),
+  });
+
+  await fullGuantr.setRules([
+    // Allow reading articles with a published author
+    {
+      effect: 'allow',
+      action: 'read',
+      resource: 'article',
+      condition: {
+        author: {
+          email: ['eq', '$ctx.email'],
+          address: {
+            city: ['eq', 'NYC'],
+          },
+        },
+      },
+    },
+    // Allow reading if description is null (unpublished placeholders)
+    {
+      effect: 'allow',
+      action: 'read',
+      resource: 'article',
+      condition: {
+        description: ['eq', null],
+      },
+    },
+  ]);
+
+  const articleWithAuthor = {
+    id: 1,
+    title: 'Test',
+    description: 'Full article',
+    author: {
+      name: 'Admin',
+      email: 'admin@test.com',
+      address: { street: '1 Main', city: 'NYC' },
+    },
+    tags: ['news'],
+    metadata: {},
+  };
+
+  assert(
+    await fullGuantr.can('read', ['article', articleWithAuthor]),
+    'End-to-end: nested condition with $ctx.email matches author.email',
+  );
+
+  const articleWithNullDesc = {
+    id: 2,
+    title: 'Draft',
+    description: null,
+    author: null,
+    tags: null,
+    metadata: {},
+  };
+
+  assert(
+    await fullGuantr.can('read', ['article', articleWithNullDesc]),
+    'End-to-end: nullable description eq null → allowed',
+  );
+
+  /* ------------------------------------------------------------------ */
+  /*  Summary                                                             */
+  /* ------------------------------------------------------------------ */
+  info(
+    'Complex resource models verified — nested objects, primitive arrays, object arrays, nullable, optional, deep nesting, union types.',
+  );
+}

--- a/playground/index.ts
+++ b/playground/index.ts
@@ -1,0 +1,48 @@
+/**
+ * Guantr Playground
+ * =================
+ *
+ * Run with:  pnpm play
+ *
+ * This playground demonstrates real-world usage patterns of the Guantr
+ * library.  It covers both untyped (plain-JS-style) and fully-typed
+ * (TypeScript) usage, all condition operators, context-driven rules,
+ * custom storage, and complex ABAC/RBAC scenarios.
+ *
+ * Each demo function is self-contained and logs results to the console.
+ * The modular structure helps verify type completions in your editor.
+ */
+
+import { demoBasic } from './demos/01-basic';
+import { demoTyped } from './demos/02-typed';
+import { demoOperators } from './demos/03-operators';
+import { demoContext } from './demos/04-context';
+import { demoArrayOperators } from './demos/05-array-operators';
+import { demoStorage } from './demos/06-storage';
+import { demoAdvanced } from './demos/07-advanced';
+import { demoComplexContext } from './demos/08-complex-context';
+import { demoComplexModel } from './demos/09-complex-model';
+
+async function main() {
+  console.log('══════════════════════════════════════════════════════');
+  console.log('           Guantr Playground');
+  console.log('══════════════════════════════════════════════════════\n');
+
+  await demoBasic();
+  await demoTyped();
+  await demoOperators();
+  await demoContext();
+  await demoArrayOperators();
+  await demoStorage();
+  await demoAdvanced();
+  await demoComplexContext();
+  await demoComplexModel();
+
+  console.log('\n══════════════════════════════════════════════════════');
+  console.log('  All demos completed successfully.');
+  console.log('══════════════════════════════════════════════════════');
+}
+
+main().catch((err) => {
+  console.error('Playground error:', err);
+});

--- a/playground/utils.ts
+++ b/playground/utils.ts
@@ -1,0 +1,151 @@
+/**
+ * Shared utilities for playground demos.
+ */
+
+/* ------------------------------------------------------------------ */
+/*  Logging helpers                                                     */
+/* ------------------------------------------------------------------ */
+export function heading(title: string): void {
+  console.log(`\n${'═'.repeat(72)}`);
+  console.log(`  ${title}`);
+  console.log(`${'═'.repeat(72)}`);
+}
+
+export function sub(title: string): void {
+  console.log(`\n  ── ${title} ──`);
+}
+
+export function pass(msg: string): void {
+  console.log(`  ✅ ${msg}`);
+}
+
+export function fail(msg: string): void {
+  console.log(`  ❌ ${msg}`);
+}
+
+export function info(msg: string): void {
+  console.log(`  ℹ️  ${msg}`);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Assertion helpers                                                   */
+/* ------------------------------------------------------------------ */
+export function assert(condition: boolean, msg: string): asserts condition {
+  if (!condition) {
+    fail(msg);
+    throw new Error(`Assertion failed: ${msg}`);
+  }
+  pass(msg);
+}
+
+export async function assertRejects(fn: () => Promise<unknown>, msg: string): Promise<void> {
+  try {
+    await fn();
+    fail(msg);
+  } catch {
+    pass(msg);
+  }
+}
+
+import type { GuantrRuleCondition } from '../src/index';
+/* ------------------------------------------------------------------ */
+/*  Test helper: type-safe matchRuleCondition wrapper                   */
+/*  Avoids `as any` casts in demo files by accepting a plain object.   */
+/* ------------------------------------------------------------------ */
+import { matchRuleCondition } from '../src/index';
+
+/**
+ * Wraps matchRuleCondition so demo code can pass untyped condition
+ * objects without requiring `as any` casts.
+ */
+export function testMatch(model: Record<string, unknown>, condition: GuantrRuleCondition): boolean {
+  return matchRuleCondition(model, condition);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Sample models used across demos                                     */
+/* ------------------------------------------------------------------ */
+
+/** A simple post model used in typed demos */
+export type Post = {
+  id: number;
+  title: string;
+  content: string;
+  status: 'draft' | 'published' | 'archived';
+  authorId: number;
+  tags: string[];
+  metadata: {
+    views: number;
+    featured: boolean;
+    category: string;
+  };
+  comments: Array<{
+    id: number;
+    userId: number;
+    text: string;
+    moderated: boolean;
+  }>;
+};
+
+/** A user model */
+export type User = {
+  id: number;
+  email: string;
+  role: 'admin' | 'editor' | 'viewer';
+  profile: {
+    displayName: string;
+    avatarUrl: string | null;
+  };
+  permissions: string[];
+};
+
+/** A comment model */
+export type Comment = {
+  id: number;
+  postId: number;
+  userId: number;
+  text: string;
+  flagged: boolean;
+  moderated: boolean;
+};
+
+/** Application context for blog demos */
+export type BlogContext = {
+  userId: number;
+  userRole: 'admin' | 'editor' | 'viewer';
+  isAuthenticated: boolean;
+  teamId?: number;
+};
+
+/** Make a sample published post */
+export function publishedPost(overrides?: Partial<Post>): Post {
+  return {
+    id: 1,
+    title: 'Hello World',
+    content: 'This is a published post',
+    status: 'published',
+    authorId: 1,
+    tags: ['news', 'tech', 'typescript'],
+    metadata: { views: 100, featured: true, category: 'tech' },
+    comments: [
+      { id: 1, userId: 2, text: 'Great post!', moderated: true },
+      { id: 2, userId: 3, text: 'Spam', moderated: false },
+    ],
+    ...overrides,
+  };
+}
+
+/** Make a sample draft post */
+export function draftPost(overrides?: Partial<Post>): Post {
+  return {
+    id: 2,
+    title: 'Work in Progress',
+    content: 'Still writing...',
+    status: 'draft',
+    authorId: 2,
+    tags: ['draft'],
+    metadata: { views: 0, featured: false, category: '' },
+    comments: [],
+    ...overrides,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,10 @@
 import type { Storage } from './storage/types';
 import type {
   GuantrMeta,
-  GuantrAnyRule,
   GuantrRule,
   GuantrResourceMap,
   GuantrOptions,
+  GuantrContextFromMeta,
 } from './types';
 import { GuantrCircuitBreakerError } from './errors';
 import { InMemoryStorage } from './storage';
@@ -31,9 +31,8 @@ export type {
   GuantrResourceMap,
   GuantrRule,
   GuantrRuleCondition,
-  GuantrAnyRuleCondition,
-  GuantrAnyRuleConditionExpression,
-  GuantrAnyRule,
+  GuantrRuleConditionExpression,
+  GuantrContextFromMeta,
 } from './types';
 
 export {
@@ -112,12 +111,9 @@ type CannotMethod<Meta extends GuantrMeta<GuantrResourceMap> | undefined> = {
   ): Promise<boolean>;
 };
 
-export class Guantr<
-  Meta extends GuantrMeta<GuantrResourceMap> | undefined = undefined,
-  Context extends Record<string, unknown> = Record<string, unknown>,
-> {
+export class Guantr<Meta extends GuantrMeta<GuantrResourceMap> | undefined = undefined> {
   private _storage: Storage;
-  private _getContext: () => Context | PromiseLike<Context>;
+  private _getContext: () => GuantrContextFromMeta<Meta> | PromiseLike<GuantrContextFromMeta<Meta>>;
   private readonly _maxRuleIterations: number;
   /**
    * Check whether an action is permitted on a resource.
@@ -136,15 +132,15 @@ export class Guantr<
   readonly cannot!: CannotMethod<Meta>;
 
   /**
-   * Initializes a new instance of the Guantr class with an optional ctx.
+   * Initializes a new instance of the Guantr class.
    *
    * @param {Object} options - An optional object containing the context & storage configuration.
-   * @param {Context} options.context - Optional context object to set.
    * @param {Storage} options.storage - Optional storage object to use. Defaults to InMemoryStorage.
    */
-  constructor(options?: GuantrOptions<Context>) {
+  constructor(options?: GuantrOptions<GuantrContextFromMeta<Meta>>) {
     this._storage = options?.storage || new InMemoryStorage();
-    this._getContext = options?.getContext || (() => Promise.resolve({} as Context));
+    this._getContext =
+      options?.getContext || (() => Promise.resolve({} as GuantrContextFromMeta<Meta>));
 
     const maxRuleIterations = options?.maxRuleIterations ?? 1000;
     if (!Number.isInteger(maxRuleIterations) || maxRuleIterations < 1) {
@@ -197,34 +193,32 @@ export class Guantr<
    * @param {Function} callback.can - The function to set rules when allowed.
    * @param {Function} callback.cannot - The function to set rules when denied.
    */
-  async setRules(callback: SetRulesCallback<Meta, Context>): Promise<void>;
+  async setRules(callback: SetRulesCallback<Meta>): Promise<void>;
   /**
    * Sets the rules for the Guantr instance.
    *
-   * @param {GuantrRule<Meta, Context>[]} rules - The array of rules to set.
+   * @param {GuantrRule<Meta>[]} rules - The array of rules to set.
    */
-  async setRules(rules: GuantrRule<Meta, Context>[]): Promise<void>;
-  async setRules(
-    callbackOrRules: SetRulesCallback<Meta, Context> | GuantrRule<Meta, Context>[],
-  ): Promise<void> {
-    let nextRules: GuantrAnyRule[];
+  async setRules(rules: GuantrRule<Meta>[]): Promise<void>;
+  async setRules(callbackOrRules: SetRulesCallback<Meta> | GuantrRule<Meta>[]): Promise<void> {
+    let nextRules: GuantrRule[];
 
     if (Array.isArray(callbackOrRules)) {
-      nextRules = callbackOrRules as GuantrAnyRule[];
+      nextRules = callbackOrRules as GuantrRule[];
       for (const rule of nextRules) {
         if (rule.condition !== null) {
           validateCondition(rule.condition);
         }
       }
     } else {
-      const rules: GuantrAnyRule[] = [];
+      const rules: GuantrRule[] = [];
       await callbackOrRules(
         (action, resource) =>
           rules.push({
             action,
             resource: typeof resource === 'string' ? resource : resource[0],
             condition:
-              typeof resource === 'string' ? null : (resource[1] as GuantrAnyRule['condition']),
+              typeof resource === 'string' ? null : (resource[1] as GuantrRule['condition']),
             effect: 'allow',
           }),
         (action, resource) =>
@@ -232,7 +226,7 @@ export class Guantr<
             action,
             resource: typeof resource === 'string' ? resource : resource[0],
             condition:
-              typeof resource === 'string' ? null : (resource[1] as GuantrAnyRule['condition']),
+              typeof resource === 'string' ? null : (resource[1] as GuantrRule['condition']),
             effect: 'deny',
           }),
       );
@@ -251,17 +245,17 @@ export class Guantr<
   }
 
   /**
-   * Returns the rules of the Guantr instance as a read-only array of GuantrAnyRule objects.
+   * Returns the rules of the Guantr instance as a read-only array of GuantrRule objects.
    *
-   * @return {Promise<ReadonlyArray<GuantrAnyRule>>} The rules of the Guantr instance.
+   * @return {Promise<ReadonlyArray<GuantrRule>>} The rules of the Guantr instance.
    */
-  async getRules(): Promise<ReadonlyArray<GuantrAnyRule>> {
+  async getRules(): Promise<ReadonlyArray<GuantrRule>> {
     const cacheKey = 'getRules';
     if (this._storage.cache) {
-      let cached: ReadonlyArray<GuantrAnyRule> | undefined;
+      let cached: ReadonlyArray<GuantrRule> | undefined;
       try {
         if (await this._storage.cache.has(cacheKey)) {
-          cached = await this._storage.cache.get<ReadonlyArray<GuantrAnyRule>>(cacheKey);
+          cached = await this._storage.cache.get<ReadonlyArray<GuantrRule>>(cacheKey);
         }
       } catch {
         // Swallow cache adapter errors and treat as cache miss
@@ -285,13 +279,13 @@ export class Guantr<
    * @param {ResourceKey} resource - The resource key to filter rules.
    * @param {Object} options - An optional object containing the applyConditionContextualOperands flag.
    * @param {boolean} options.applyConditionContextualOperands - A flag indicating whether to apply contextual operands to each rules condition.
-   * @return {GuantrAnyRule[]} The filtered rules based on the action and resource.
+   * @return {GuantrRule[]} The filtered rules based on the action and resource.
    */
   async relatedRulesFor<ResourceKey extends ExtractResourceKeys<Meta>>(
     action: ExtractResourceAction<Meta, ResourceKey>,
     resource: ResourceKey,
     options?: { applyConditionContextualOperands?: boolean },
-  ): Promise<GuantrAnyRule[]> {
+  ): Promise<GuantrRule[]> {
     const rules = await this._storage.queryRules(action as string, resource as string);
     if (options?.applyConditionContextualOperands) {
       return await Promise.all(
@@ -451,11 +445,11 @@ export class Guantr<
   }
 
   private async applyContextualOperands(
-    condition: GuantrAnyRule['condition'],
-    context?: Context,
+    condition: GuantrRule['condition'],
+    context?: GuantrContextFromMeta<Meta>,
     /** Pre-serialized context string, forwarded from the caller to avoid a redundant stringify. */
     serializedContext?: string,
-  ): Promise<GuantrAnyRule['condition']> {
+  ): Promise<GuantrRule['condition']> {
     if (condition == null) {
       return null;
     }
@@ -467,10 +461,10 @@ export class Guantr<
       // Reuse the pre-serialized context from the caller when available.
       const serializedCtx = serializedContext ?? JSON.stringify(resolvedContext);
       cacheKey = `applyContextualOperands/${JSON.stringify(condition)}:${serializedCtx}`;
-      let cachedResult: GuantrAnyRule['condition'] | undefined = undefined;
+      let cachedResult: GuantrRule['condition'] | undefined = undefined;
       try {
         if (await this._storage.cache.has(cacheKey)) {
-          cachedResult = await this._storage.cache.get<GuantrAnyRule['condition']>(cacheKey);
+          cachedResult = await this._storage.cache.get<GuantrRule['condition']>(cacheKey);
         }
       } catch {
         // Swallow cache adapter errors and treat as cache miss
@@ -514,52 +508,39 @@ export class Guantr<
   }
 }
 
-type SetRulesCallback<
-  Meta extends GuantrMeta<GuantrResourceMap> | undefined = undefined,
-  Context extends Record<string, unknown> = Record<string, unknown>,
-> = (
+type SetRulesCallback<Meta extends GuantrMeta<GuantrResourceMap> | undefined = undefined> = (
   can: <ResourceKey extends ExtractResourceKeys<Meta>>(
-    action: GuantrRule<Meta, Context, ResourceKey>['action'],
+    action: GuantrRule<Meta, ResourceKey>['action'],
     resource:
-      | GuantrRule<Meta, Context, ResourceKey>['resource']
-      | [
-          GuantrRule<Meta, Context, ResourceKey>['resource'],
-          GuantrRule<Meta, Context, ResourceKey>['condition'],
-        ],
+      | GuantrRule<Meta, ResourceKey>['resource']
+      | [GuantrRule<Meta, ResourceKey>['resource'], GuantrRule<Meta, ResourceKey>['condition']],
   ) => void,
   cannot: <ResourceKey extends ExtractResourceKeys<Meta>>(
-    action: GuantrRule<Meta, Context, ResourceKey>['action'],
+    action: GuantrRule<Meta, ResourceKey>['action'],
     resource:
-      | GuantrRule<Meta, Context, ResourceKey>['resource']
-      | [
-          GuantrRule<Meta, Context, ResourceKey>['resource'],
-          GuantrRule<Meta, Context, ResourceKey>['condition'],
-        ],
+      | GuantrRule<Meta, ResourceKey>['resource']
+      | [GuantrRule<Meta, ResourceKey>['resource'], GuantrRule<Meta, ResourceKey>['condition']],
   ) => void,
 ) => void | Promise<void>;
 
 export async function createGuantr<
   Meta extends GuantrMeta<GuantrResourceMap> | undefined = undefined,
-  Context extends Record<string, unknown> = Record<string, unknown>,
->(options: GuantrOptions<Context>): Promise<Guantr<Meta, Context>>;
+>(options: GuantrOptions<GuantrContextFromMeta<Meta>>): Promise<Guantr<Meta>>;
 export async function createGuantr<
   Meta extends GuantrMeta<GuantrResourceMap> | undefined = undefined,
-  Context extends Record<string, unknown> = Record<string, unknown>,
 >(
-  setRules: SetRulesCallback<Meta, Context>,
-  options?: GuantrOptions<Context>,
-): Promise<Guantr<Meta, Context>>;
+  setRules: SetRulesCallback<Meta>,
+  options?: GuantrOptions<GuantrContextFromMeta<Meta>>,
+): Promise<Guantr<Meta>>;
 export async function createGuantr<
   Meta extends GuantrMeta<GuantrResourceMap> | undefined = undefined,
-  Context extends Record<string, unknown> = Record<string, unknown>,
 >(
-  setRules: GuantrRule<Meta, Context>[],
-  options?: GuantrOptions<Context>,
-): Promise<Guantr<Meta, Context>>;
+  setRules: GuantrRule<Meta>[],
+  options?: GuantrOptions<GuantrContextFromMeta<Meta>>,
+): Promise<Guantr<Meta>>;
 export async function createGuantr<
   Meta extends GuantrMeta<GuantrResourceMap> | undefined = undefined,
-  Context extends Record<string, unknown> = Record<string, unknown>,
->(): Promise<Guantr<Meta, Context>>;
+>(): Promise<Guantr<Meta>>;
 /**
  * Creates a new instance of the Guantr class.
  *
@@ -567,24 +548,21 @@ export async function createGuantr<
  */
 export async function createGuantr<
   Meta extends GuantrMeta<GuantrResourceMap> | undefined = undefined,
-  Context extends Record<string, unknown> = Record<string, unknown>,
 >(
   setRulesOrOptions?:
-    | SetRulesCallback<Meta, Context>
-    | GuantrRule<Meta, Context>[]
-    | GuantrOptions<Context>,
-  _options?: GuantrOptions<Context>,
-): Promise<Guantr<Meta, Context>> {
-  const isSetRulesArgument = (
-    arg: unknown,
-  ): arg is GuantrRule<Meta, Context>[] | SetRulesCallback<Meta, Context> => {
+    | SetRulesCallback<Meta>
+    | GuantrRule<Meta>[]
+    | GuantrOptions<GuantrContextFromMeta<Meta>>,
+  _options?: GuantrOptions<GuantrContextFromMeta<Meta>>,
+): Promise<Guantr<Meta>> {
+  const isSetRulesArgument = (arg: unknown): arg is GuantrRule<Meta>[] | SetRulesCallback<Meta> => {
     return Array.isArray(arg) || typeof arg === 'function';
   };
   const rules = isSetRulesArgument(setRulesOrOptions) ? setRulesOrOptions : undefined;
   const options =
     _options ?? (isSetRulesArgument(setRulesOrOptions) ? undefined : setRulesOrOptions);
 
-  const instance = new Guantr<Meta, Context>(options);
+  const instance = new Guantr<Meta>(options);
   if (rules) {
     await instance.setRules(rules as any);
   }

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -1,12 +1,12 @@
-import { GuantrAnyRule } from '../types';
+import { GuantrRule } from '../types';
 import { Storage } from './types';
 
 export type { Storage } from './types';
 
 export class InMemoryStorage implements Storage {
   private storage = {
-    // Two-level index: Map<action, Map<resource, GuantrAnyRule[]>>
-    rules: new Map<string, Map<string, GuantrAnyRule[]>>(),
+    // Two-level index: Map<action, Map<resource, GuantrRule[]>>
+    rules: new Map<string, Map<string, GuantrRule[]>>(),
     cache: new Map<string, unknown>(),
   };
 
@@ -14,7 +14,7 @@ export class InMemoryStorage implements Storage {
    * Atomically replaces all stored rules with the provided rules.
    * @param rules - Array of rules to set.
    */
-  async setRules(rules: GuantrAnyRule[]) {
+  async setRules(rules: GuantrRule[]) {
     this.storage.rules.clear();
 
     for (const rule of rules) {
@@ -38,7 +38,7 @@ export class InMemoryStorage implements Storage {
    * @returns An array of all stored rules.
    */
   async getRules() {
-    const allRules: GuantrAnyRule[] = [];
+    const allRules: GuantrRule[] = [];
     for (const resourceMap of this.storage.rules.values()) {
       for (const ruleArray of resourceMap.values()) {
         allRules.push(...ruleArray);

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -1,4 +1,4 @@
-import { GuantrAnyRule } from '../types';
+import { GuantrRule } from '../types';
 
 /**
  * Interface representing a storage mechanism for managing rules and cache.
@@ -10,13 +10,13 @@ export interface Storage {
    * @param rules - Array of rules to set.
    * @returns A promise that resolves when the rules are set.
    */
-  setRules: (rules: GuantrAnyRule[]) => Promise<void>;
+  setRules: (rules: GuantrRule[]) => Promise<void>;
 
   /**
    * Retrieves all stored rules.
    * @returns A promise that resolves to an array of stored rules.
    */
-  getRules: () => Promise<GuantrAnyRule[]>;
+  getRules: () => Promise<GuantrRule[]>;
 
   /**
    * Queries rules for a given action and resource.
@@ -24,7 +24,7 @@ export interface Storage {
    * @param resource - The resource to filter by.
    * @returns A promise that resolves to an array of matching rules, or an empty array if none exist.
    */
-  queryRules: (action: string, resource: string) => Promise<GuantrAnyRule[]>;
+  queryRules: (action: string, resource: string) => Promise<GuantrRule[]>;
 
   /**
    * Optional cache mechanism for storing and retrieving data.

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,14 +137,19 @@ type ArrayConditionExpressionBasic<
       options?: string extends T[number] ? { caseInsensitive?: boolean } : never,
     ];
 
+// Internal self-referential type for untyped conditions (index signature)
+interface _GuantrUntypedRuleCondition {
+  [key: string]: GuantrRuleConditionExpression | _GuantrUntypedRuleCondition;
+}
+
 // Untyped version for ArrayConditionExpressionObject to avoid circular reference
 type ArrayConditionExpressionObjectUntyped =
   | [operator: 'some', operand: Record<string, any>]
   | [operator: 'every', operand: Record<string, any>]
   | [operator: 'none', operand: Record<string, any>];
 
-// Export the any-typed version for runtime use
-export type GuantrAnyRuleConditionExpression =
+// The untyped condition expression (default when no generics provided)
+export type GuantrRuleConditionExpression =
   | NullishConditionExpression<null | undefined>
   | StringConditionExpression
   | NumberConditionExpression
@@ -161,36 +166,37 @@ type ArrayConditionExpressionObject<
   | [
       operator: 'some',
       operand: Typed extends false
-        ? Record<string, GuantrAnyRuleConditionExpression>
+        ? Record<string, GuantrRuleConditionExpression>
         : GuantrRuleCondition<T[number], Context>,
     ]
   | [
       operator: 'every',
       operand: Typed extends false
-        ? Record<string, GuantrAnyRuleConditionExpression>
+        ? Record<string, GuantrRuleConditionExpression>
         : GuantrRuleCondition<T[number], Context>,
     ]
   | [
       operator: 'none',
       operand: Typed extends false
-        ? Record<string, GuantrAnyRuleConditionExpression>
+        ? Record<string, GuantrRuleConditionExpression>
         : GuantrRuleCondition<T[number], Context>,
     ];
 
-export interface GuantrAnyRuleCondition {
-  [key: string]: GuantrAnyRuleConditionExpression | GuantrAnyRuleCondition;
-}
+/**
+ * Extracts the Context type from a GuantrMeta, or defaults to Record<string, unknown>.
+ */
+export type GuantrContextFromMeta<Meta extends GuantrMeta<GuantrResourceMap> | undefined> =
+  Meta extends GuantrMeta<any, infer C> ? C : Record<string, unknown>;
 
-export type GuantrAnyRule = {
-  resource: string;
-  action: string;
-  condition: GuantrAnyRuleCondition | null;
-  effect: 'allow' | 'deny';
-};
-
+/**
+ * A rule in the authorization system.
+ *
+ * - When `Meta` is provided (typed mode), `resource`, `action`, and `condition` are
+ *   narrowed based on the resource map.
+ * - When `Meta` is omitted (untyped mode), all fields accept plain strings / any condition.
+ */
 export type GuantrRule<
   Meta extends GuantrMeta<GuantrResourceMap> | undefined = undefined,
-  Context extends Record<string, unknown> = Record<string, unknown>,
   ResourceKey extends Meta extends GuantrMeta<infer U> ? keyof U : string = Meta extends GuantrMeta<
     infer U
   >
@@ -201,10 +207,18 @@ export type GuantrRule<
     ? {
         resource: ResourceKey;
         action: ResourceMap[ResourceKey]['action'];
-        condition: GuantrRuleCondition<ResourceMap[ResourceKey]['model'], Context> | null;
+        condition: GuantrRuleCondition<
+          ResourceMap[ResourceKey]['model'],
+          GuantrContextFromMeta<Meta>
+        > | null;
         effect: 'allow' | 'deny';
       }
-    : GuantrAnyRule;
+    : {
+        resource: string;
+        action: string;
+        condition: GuantrRuleCondition | null;
+        effect: 'allow' | 'deny';
+      };
 
 export type LeafKeysValuePair<Obj extends Record<string, unknown>> = {
   [P in string & LeafKeys<Obj>]: Value<Obj, P>;
@@ -244,12 +258,20 @@ type ResolveConditionExpression<
     ? GuantrRuleCondition<T, Context>
     : ConditionExpression<T, Context>;
 
+/**
+ * A condition object for a rule.
+ *
+ * - Without generics: accepts any keys with `GuantrRuleConditionExpression` values
+ *   or nested conditions (index-signature fallback).
+ * - With `<Model, Context>`: keys are narrowed to the model's properties and the
+ *   expression types are narrowed accordingly.
+ */
 export type GuantrRuleCondition<
-  Model extends Record<string, unknown>,
+  Model extends Record<string, unknown> = Record<string, unknown>,
   Context extends Record<string, unknown> = Record<string, unknown>,
-> = Model extends any
-  ? Partial<{ [K in keyof Model]: ResolveConditionExpression<Model[K], Context> }>
-  : never;
+> = string extends keyof Model
+  ? _GuantrUntypedRuleCondition
+  : Partial<{ [K in keyof Model]: ResolveConditionExpression<Model[K], Context> }>;
 
 // Optimized LeafKeys with depth limit to prevent infinite recursion
 type LeafKeys<

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,9 +2,9 @@ import { GuantrInvalidConditionError, GuantrInvalidConditionOperatorError } from
 import {
   ConditionOperator,
   ConditionOptions,
-  GuantrAnyRuleCondition,
-  GuantrAnyRuleConditionExpression,
-  GuantrAnyRule,
+  GuantrRuleCondition,
+  GuantrRuleConditionExpression,
+  GuantrRule,
 } from './types';
 
 /**
@@ -95,11 +95,11 @@ export const KNOWN_OPERATORS: ReadonlySet<string> = new Set<ConditionOperator>([
  * `matchConditionExpression` (at evaluation time).
  *
  * @param {unknown} maybeExpression - The value to check.
- * @return {maybeExpression is GuantrAnyRuleConditionExpression} - Returns true if the value is a structurally valid condition expression, otherwise returns false.
+ * @return {maybeExpression is GuantrRuleConditionExpression} - Returns true if the value is a structurally valid condition expression, otherwise returns false.
  */
 export const isConditionExpressionLike = (
   maybeExpression: unknown,
-): maybeExpression is GuantrAnyRuleConditionExpression => {
+): maybeExpression is GuantrRuleConditionExpression => {
   if (
     !Array.isArray(maybeExpression) ||
     maybeExpression.length < 2 ||
@@ -118,11 +118,11 @@ export const isConditionExpressionLike = (
  * This is called by `setRules` to catch problems at definition time rather than
  * throwing at evaluation time.
  *
- * @param {GuantrAnyRule['condition']} condition - The condition to validate.
+ * @param {GuantrRule['condition']} condition - The condition to validate.
  * @param {string} [_path] - Dot-notation path used for error messages (populated by recursion).
  * @throws {GuantrInvalidConditionError}
  */
-export function validateCondition(condition: GuantrAnyRule['condition'], _path: string = ''): void {
+export function validateCondition(condition: GuantrRule['condition'], _path: string = ''): void {
   if (condition === null || condition === undefined) return;
   if (!isPlainObject(condition)) {
     throw new GuantrInvalidConditionError(
@@ -158,7 +158,7 @@ function _validateConditionValue(value: unknown, path: string): void {
       (operator === 'some' || operator === 'every' || operator === 'none') &&
       isPlainObject(value[1])
     ) {
-      validateCondition(value[1] as GuantrAnyRuleCondition, path);
+      validateCondition(value[1] as GuantrRuleCondition, path);
     }
   } else if (isPlainObject(value)) {
     // Could be a nested condition object (possibly with a $expr sibling key)
@@ -166,7 +166,7 @@ function _validateConditionValue(value: unknown, path: string): void {
     if ($expr !== undefined) {
       _validateConditionValue($expr, `${path}.$expr`);
     }
-    validateCondition(nested as GuantrAnyRuleCondition, path);
+    validateCondition(nested as GuantrRuleCondition, path);
   } else {
     throw new GuantrInvalidConditionError(
       value,
@@ -562,7 +562,7 @@ function checkComplexCondition(
 
       return matchRuleCondition(
         item[key] as Record<string, unknown>,
-        expressionOrNestedCondition as GuantrAnyRuleCondition,
+        expressionOrNestedCondition as GuantrRuleCondition,
       );
     } else {
       throw new TypeError(
@@ -576,12 +576,12 @@ function checkComplexCondition(
  * Checks if the given model matches the rule condition.
  *
  * @param {Model} model - The model to check against the rule condition.
- * @param {GuantrAnyRule & { condition: NonNullable<GuantrAnyRule['condition']> }} condition - The condition to match.
+ * @param {GuantrRule & { condition: NonNullable<GuantrRule['condition']> }} condition - The condition to match.
  * @returns {boolean} Returns true if the model matches the rule condition, false otherwise.
  */
 export const matchRuleCondition = <Model extends Record<string, unknown>>(
   model: Model,
-  condition: NonNullable<GuantrAnyRule['condition']>,
+  condition: NonNullable<GuantrRule['condition']>,
 ): boolean => {
   if (!model) {
     return false;
@@ -623,7 +623,7 @@ export const matchRuleCondition = <Model extends Record<string, unknown>>(
  *
  * @param {Object} data - The data object containing the value and expression.
  * @param {unknown} data.value - The value to evaluate the condition against.
- * @param {NonNullable<GuantrAnyRule['condition']>[keyof NonNullable<GuantrAnyRule['condition']>]} data.expression - The condition expression to evaluate.
+ * @param {NonNullable<GuantrRule['condition']>[keyof NonNullable<GuantrRule['condition']>]} data.expression - The condition expression to evaluate.
  * @return {boolean} The result of evaluating the condition expression against the value.
  * @throws {GuantrInvalidConditionOperatorError} If the operator is not a known ConditionOperator.
  * @throws {TypeError} If the model value type is unexpected or the operand type is invalid.
@@ -631,7 +631,7 @@ export const matchRuleCondition = <Model extends Record<string, unknown>>(
 export const matchConditionExpression = (data: {
   value: unknown;
   expression: Extract<
-    NonNullable<GuantrAnyRule['condition']>[keyof NonNullable<GuantrAnyRule['condition']>],
+    NonNullable<GuantrRule['condition']>[keyof NonNullable<GuantrRule['condition']>],
     Array<any>
   >;
 }): boolean => {

--- a/tests/cache-invalidation.test.ts
+++ b/tests/cache-invalidation.test.ts
@@ -1,4 +1,3 @@
-import type { GuantrAnyRule } from '../src/types';
 import { describe, expect, it } from 'vitest';
 import { Guantr } from '../src/index';
 import { InMemoryStorage } from '../src/storage';
@@ -64,7 +63,7 @@ describe('cache invalidation after setRules', () => {
         effect: 'allow',
         action: 'read',
         resource: 'post',
-        condition: { id: ['eq', 1] } as GuantrAnyRule['condition'],
+        condition: { id: ['eq', 1] },
       },
     ]);
     expect(await guantr.can('read', ['post', { id: 1 }])).toBe(true);
@@ -75,7 +74,7 @@ describe('cache invalidation after setRules', () => {
         effect: 'allow',
         action: 'read',
         resource: 'post',
-        condition: { id: ['eq', 2] } as GuantrAnyRule['condition'],
+        condition: { id: ['eq', 2] },
       },
     ]);
     expect(await guantr.can('read', ['post', { id: 1 }])).toBe(false);
@@ -87,7 +86,7 @@ describe('cache invalidation after setRules', () => {
         effect: 'allow',
         action: 'read',
         resource: 'post',
-        condition: { id: ['eq', 1] } as GuantrAnyRule['condition'],
+        condition: { id: ['eq', 1] },
       },
     ]);
     expect(await guantr.can('read', ['post', { id: 1 }])).toBe(true);

--- a/tests/custom-storage.test.ts
+++ b/tests/custom-storage.test.ts
@@ -1,5 +1,5 @@
 import type { Storage } from '../src/storage/types';
-import type { GuantrAnyRule } from '../src/types';
+import type { GuantrRule } from '../src/types';
 import { describe, expect, it } from 'vitest';
 import { createGuantr, Guantr } from '../src/index';
 
@@ -8,9 +8,9 @@ import { createGuantr, Guantr } from '../src/index';
 // Note: setRules atomically replaces the internal array.
 // ---------------------------------------------------------------------------
 class CustomArrayStorage implements Storage {
-  private rules: GuantrAnyRule[] = [];
+  private rules: GuantrRule[] = [];
 
-  async setRules(rules: GuantrAnyRule[]) {
+  async setRules(rules: GuantrRule[]) {
     this.rules = [...rules];
   }
 
@@ -92,7 +92,7 @@ describe('custom storage adapter integration', () => {
 
   it('getRules(): returns all rules that were stored via setRules()', async () => {
     const guantr = new Guantr({ storage: new CustomArrayStorage() });
-    const rules: GuantrAnyRule[] = [
+    const rules: GuantrRule[] = [
       { resource: 'post', action: 'read', condition: null, effect: 'allow' },
       { resource: 'post', action: 'delete', condition: null, effect: 'deny' },
     ];

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,4 +1,4 @@
-import type { GuantrMeta, GuantrRule, GuantrResourceMap, GuantrAnyRule } from '../src';
+import type { GuantrMeta, GuantrRule, GuantrResourceMap } from '../src';
 import { describe, expect, it, test } from 'vitest';
 import { createGuantr } from '../src';
 
@@ -338,7 +338,7 @@ describe('Guantr.can', () => {
       } as { name: string } | null,
     };
 
-    const guantr1 = await createGuantr<MockMeta, typeof mockContext1>(
+    const guantr1 = await createGuantr<MockMeta>(
       [
         {
           resource: 'user',
@@ -352,7 +352,7 @@ describe('Guantr.can', () => {
       { getContext: () => mockContext1 },
     );
 
-    const guantr2 = await createGuantr<MockMeta, typeof mockContext1>(
+    const guantr2 = await createGuantr<MockMeta>(
       [
         {
           resource: 'user',
@@ -434,7 +434,7 @@ describe('Guantr.can', () => {
       },
     ]);
 
-    const guantr2 = await createGuantr<MockMeta, typeof mockContext2>(
+    const guantr2 = await createGuantr<MockMeta>(
       [
         {
           resource: 'user',
@@ -475,7 +475,7 @@ describe('Guantr.can', () => {
 
   it('should handle circuit breaker in can method', async () => {
     const guantr = await createGuantr();
-    const rules: GuantrAnyRule[] = [];
+    const rules: GuantrRule[] = [];
     // 1001 rules should trip the default circuit breaker (limit: 1000)
     for (let i = 0; i < 1001; i++) {
       rules.push({

--- a/tests/type-inference.test.ts
+++ b/tests/type-inference.test.ts
@@ -1,0 +1,178 @@
+import type { ConditionOperator } from '../src/index';
+/**
+ * This file verifies that type inference works correctly with the v2 API.
+ * It is NOT meant to be executed at runtime — only type-checked.
+ */
+import { describe, it } from 'vitest';
+import {
+  createGuantr,
+  Guantr,
+  GuantrMeta,
+  GuantrResourceMap,
+  GuantrRule,
+  GuantrRuleCondition,
+  GuantrRuleConditionExpression,
+  GuantrContextFromMeta,
+  GuantrOptions,
+} from '../src/index';
+
+// ---------------------------------------------------------------------------
+// Setup: resource map and meta types
+// ---------------------------------------------------------------------------
+type MyResourceMap = GuantrResourceMap<{
+  article: {
+    action: 'read' | 'create' | 'update' | 'delete';
+    model: {
+      id: string;
+      title: string;
+      status: 'draft' | 'published';
+      tags: string[];
+    };
+  };
+  user: {
+    action: 'read' | 'update';
+    model: {
+      id: number;
+      name: string;
+      role: 'admin' | 'user';
+    };
+  };
+}>;
+
+type MyContext = {
+  userId: string;
+  role: 'admin' | 'user';
+};
+
+type MyMeta = GuantrMeta<MyResourceMap, MyContext>;
+
+describe('Type inference (compile-time only)', () => {
+  it('GuantrRule without generics is untyped', () => {
+    // Should compile: untyped GuantrRule accepts any strings
+    const _rule: GuantrRule = {
+      effect: 'allow',
+      action: 'anything',
+      resource: 'anything',
+      condition: null,
+    };
+
+    // Should compile: condition can be any object
+    const _ruleWithCondition: GuantrRule = {
+      effect: 'deny',
+      action: 'read',
+      resource: 'post',
+      condition: {
+        someKey: ['eq', 'someValue'],
+        nested: {
+          anotherKey: ['gt', 5],
+        },
+      },
+    };
+  });
+
+  it('GuantrRule with Meta is typed', () => {
+    // Should compile: typed GuantrRule narrows resource and action
+    const _rule2: GuantrRule<MyMeta> = {
+      effect: 'allow',
+      resource: 'article',
+      action: 'read',
+      condition: {
+        status: ['eq', 'draft'],
+        title: ['contains', 'hello'],
+      },
+    };
+
+    // Verify typed rule: correct values compile
+    const _rule3: GuantrRule<MyMeta> = {
+      effect: 'allow',
+      resource: 'article',
+      action: 'read',
+      condition: null,
+    };
+  });
+
+  it('GuantrRuleCondition without generics is untyped', () => {
+    // Should compile: untyped condition accepts any keys
+    const _condition: GuantrRuleCondition = {
+      anyKey: ['eq', 'value'],
+      nested: {
+        anotherKey: ['gt', 5],
+      },
+    };
+  });
+
+  it('GuantrRuleCondition with Model is typed', () => {
+    // Should compile: typed condition narrows to model properties
+    const _condition2: GuantrRuleCondition<{ id: number; name: string }> = {
+      id: ['eq', 1],
+      name: ['eq', 'test'],
+    };
+
+    // Verify typed condition: correct keys compile
+    const _condition3: GuantrRuleCondition<{ id: number; name: string }> = {
+      id: ['eq', 1],
+      name: ['eq', 'test'],
+    };
+  });
+
+  it('GuantrContextFromMeta extracts Context from Meta', () => {
+    // Should compile: extracts MyContext from MyMeta
+    type Extracted = GuantrContextFromMeta<MyMeta>;
+    const _ctx: Extracted = { userId: '123', role: 'admin' };
+
+    // Should be Record<string, unknown> for undefined Meta
+    type ExtractedDefault = GuantrContextFromMeta<undefined>;
+    const _ctxDefault: ExtractedDefault = {};
+  });
+
+  it('createGuantr with Meta infers Context from Meta', async () => {
+    // Should compile: Context is inferred from MyMeta (MyContext)
+    const guantr = await createGuantr<MyMeta>({
+      // getContext return type is inferred as MyContext
+      getContext: () => ({ userId: '123', role: 'admin' as const }),
+    });
+
+    // can/cannot are typed
+    await guantr.can('read', ['article', { id: '1', title: 'Test', status: 'draft', tags: [] }]);
+  });
+
+  it('createGuantr with Meta and setRules callback', async () => {
+    const guantr = await createGuantr<MyMeta>();
+
+    // setRules callback: allow/deny are typed
+    await guantr.setRules((allow, deny) => {
+      // Should autocomplete: 'read' is a valid action for 'article'
+      allow('read', 'article');
+
+      // Should autocomplete: condition keys are model properties
+      allow('read', ['article', { status: ['eq', 'draft'] }]);
+
+      // $ctx autocompletion
+      allow('read', ['article', { id: ['eq', '$ctx.userId'] }]);
+
+      deny('delete', ['article', { status: ['eq', 'published'] }]);
+    });
+  });
+
+  it('Guantr class constructor with Meta', () => {
+    // Should compile: no Context generic needed
+    const _guantr2 = new Guantr<MyMeta>({
+      getContext: () => ({ userId: '123', role: 'admin' as const }),
+    });
+  });
+
+  it('GuantrOptions uses GuantrContextFromMeta', () => {
+    // Should compile: options typed with proper Context
+    const _options: GuantrOptions<MyContext> = {
+      getContext: () => ({ userId: '123', role: 'admin' }),
+    };
+  });
+
+  it('ConditionOperator is still exported', () => {
+    const _op: ConditionOperator = 'eq';
+  });
+
+  it('GuantrRuleConditionExpression is exported', () => {
+    const _expr: GuantrRuleConditionExpression = ['eq', 'hello'];
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,5 +7,5 @@
     "strict": true,
     "skipLibCheck": true
   },
-  "include": ["src", "tests"]
+  "include": ["playground", "src", "tests"]
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

Closes #89, Closes #90

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Context is now inferred from Meta via GuantrContextFromMeta. Rename GuantrAnyRule to GuantrRule and GuantrAnyRuleConditionExpressio  to GuantrRuleConditionExpression. Add playground demos and type inference tests.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
